### PR TITLE
Changed level from error to warn on refresh token

### DIFF
--- a/source/Core/Validation/TokenRequestValidator.cs
+++ b/source/Core/Validation/TokenRequestValidator.cs
@@ -458,7 +458,7 @@ namespace Thinktecture.IdentityServer.Core.Validation
             if (refreshToken == null)
             {
                 var error = "Refresh token is invalid";
-                LogError(error);
+                LogWarn(error);
                 RaiseRefreshTokenRefreshFailureEvent(refreshTokenHandle, error);
 
                 return Invalid(Constants.TokenErrors.InvalidGrant);
@@ -470,7 +470,7 @@ namespace Thinktecture.IdentityServer.Core.Validation
             if (refreshToken.CreationTime.HasExceeded(refreshToken.LifeTime))
             {
                 var error = "Refresh token has expired";
-                LogError(error);
+                LogWarn(error);
                 RaiseRefreshTokenRefreshFailureEvent(refreshTokenHandle, error);
 
                 await _refreshTokens.RemoveAsync(refreshTokenHandle);
@@ -638,6 +638,14 @@ namespace Thinktecture.IdentityServer.Core.Validation
             var json = LogSerializer.Serialize(validationLog);
 
             Logger.ErrorFormat("{0}\n {1}", message, json);
+        }
+
+        private void LogWarn(string message)
+        {
+            var validationLog = new TokenRequestValidationLog(_validatedRequest);
+            var json = LogSerializer.Serialize(validationLog);
+
+            Logger.WarnFormat("{0}\n {1}", message, json);
         }
 
         private void LogSuccess()


### PR DESCRIPTION
Invalid tokens
Expired tokens

These are not really unexpected behaviours, but may just appear if the client is idle for a while. 
