### PR TITLE
Only discover your own, internal, WebAPI controllers.

### DIFF
--- a/source/Core/Configuration/Hosting/WebApiConfig.cs
+++ b/source/Core/Configuration/Hosting/WebApiConfig.cs
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
+using System;
 using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
 using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Dispatcher;
 using System.Web.Http.ExceptionHandling;
 using Thinktecture.IdentityServer.Core.Logging;
 
@@ -32,7 +37,7 @@ namespace Thinktecture.IdentityServer.Core.Configuration.Hosting
 
             config.MessageHandlers.Insert(0, new KatanaDependencyResolver());
             config.Services.Add(typeof(IExceptionLogger), new LogProviderExceptionLogger());
-
+            config.Services.Replace(typeof(IHttpControllerTypeResolver), new HttpControllerTypeResolver());
             config.Formatters.Remove(config.Formatters.XmlFormatter);
 
             config.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.LocalOnly;
@@ -54,6 +59,19 @@ namespace Thinktecture.IdentityServer.Core.Configuration.Hosting
             }
 
             return config;
+        }
+
+        private class HttpControllerTypeResolver : IHttpControllerTypeResolver
+        {
+            public ICollection<Type> GetControllerTypes(IAssembliesResolver _)
+            {
+                var httpControllerType = typeof (IHttpController);
+                return typeof (WebApiConfig)
+                    .Assembly
+                    .GetTypes()
+                    .Where(t => t.IsClass && !t.IsAbstract && httpControllerType.IsAssignableFrom(t))
+                    .ToList();
+            }
         }
     }
 }

--- a/source/Core/Endpoints/AuthenticationController.cs
+++ b/source/Core/Endpoints/AuthenticationController.cs
@@ -46,7 +46,7 @@ namespace Thinktecture.IdentityServer.Core.Endpoints
     [NoCache]
     [PreventUnsupportedRequestMediaTypes(allowFormUrlEncoded: true)]
     [HostAuthentication(Constants.PrimaryAuthenticationType)]
-    public class AuthenticationController : ApiController
+    internal class AuthenticationController : ApiController
     {
         public const int MaxInputParamLength = 100;
 
@@ -67,13 +67,13 @@ namespace Thinktecture.IdentityServer.Core.Endpoints
 
         public AuthenticationController(
             OwinEnvironmentService owin,
-            IViewService viewService, 
-            IUserService userService, 
-            IdentityServerOptions idSvrOptions, 
-            IClientStore clientStore, 
+            IViewService viewService,
+            IUserService userService,
+            IdentityServerOptions idSvrOptions,
+            IClientStore clientStore,
             IEventService eventService,
             ILocalizationService localizationService,
-            SessionCookie sessionCookie, 
+            SessionCookie sessionCookie,
             MessageCookie<SignInMessage> signInMessageCookie,
             MessageCookie<SignOutMessage> signOutMessageCookie,
             LastUserNameCookie lastUsernameCookie,

--- a/source/Core/Endpoints/ClientPermissionsController.cs
+++ b/source/Core/Endpoints/ClientPermissionsController.cs
@@ -42,7 +42,7 @@ namespace Thinktecture.IdentityServer.Core.Endpoints
     [SecurityHeaders]
     [NoCache]
     [PreventUnsupportedRequestMediaTypes(allowFormUrlEncoded: true)]
-    public class ClientPermissionsController : ApiController
+    internal class ClientPermissionsController : ApiController
     {
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
 

--- a/source/Core/Endpoints/Connect/AccessTokenValidationController.cs
+++ b/source/Core/Endpoints/Connect/AccessTokenValidationController.cs
@@ -37,7 +37,7 @@ namespace Thinktecture.IdentityServer.Core.Endpoints
     [EditorBrowsable(EditorBrowsableState.Never)]
     [RoutePrefix(Constants.RoutePaths.Oidc.AccessTokenValidation)]
     [NoCache]
-    public class AccessTokenValidationController : ApiController
+    internal class AccessTokenValidationController : ApiController
     {
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
         private readonly TokenValidator _validator;

--- a/source/Core/Endpoints/Connect/AuthorizeEndpointController.cs
+++ b/source/Core/Endpoints/Connect/AuthorizeEndpointController.cs
@@ -46,7 +46,7 @@ namespace Thinktecture.IdentityServer.Core.Endpoints
     [SecurityHeaders]
     [NoCache]
     [PreventUnsupportedRequestMediaTypes(allowFormUrlEncoded: true)]
-    public class AuthorizeEndpointController : ApiController
+    internal class AuthorizeEndpointController : ApiController
     {
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
 

--- a/source/Core/Endpoints/Connect/CheckSessionEndpointController.cs
+++ b/source/Core/Endpoints/Connect/CheckSessionEndpointController.cs
@@ -27,7 +27,7 @@ namespace Thinktecture.IdentityServer.Core.Endpoints
     /// <summary>
     /// Check session iframe endpoint
     /// </summary>
-    public class CheckSessionEndpointController : ApiController
+    internal class CheckSessionEndpointController : ApiController
     {
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
         private readonly IdentityServerOptions _options;

--- a/source/Core/Endpoints/Connect/DiscoveryEndpointController.cs
+++ b/source/Core/Endpoints/Connect/DiscoveryEndpointController.cs
@@ -36,7 +36,7 @@ namespace Thinktecture.IdentityServer.Core.Endpoints
     /// OpenID Connect discovery document endpoint
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class DiscoveryEndpointController : ApiController
+    internal class DiscoveryEndpointController : ApiController
     {
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
         private readonly IdentityServerOptions _options;

--- a/source/Core/Endpoints/Connect/EndSessionController.cs
+++ b/source/Core/Endpoints/Connect/EndSessionController.cs
@@ -37,7 +37,7 @@ namespace Thinktecture.IdentityServer.Core.Endpoints
     [SecurityHeaders]
     [NoCache]
     [HostAuthentication(Constants.PrimaryAuthenticationType)]
-    public class EndSessionController : ApiController
+    internal class EndSessionController : ApiController
     {
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
 

--- a/source/Core/Endpoints/Connect/IdentityTokenValidationController.cs
+++ b/source/Core/Endpoints/Connect/IdentityTokenValidationController.cs
@@ -37,7 +37,7 @@ namespace Thinktecture.IdentityServer.Core.Endpoints
     [EditorBrowsable(EditorBrowsableState.Never)]
     [RoutePrefix(Constants.RoutePaths.Oidc.IdentityTokenValidation)]
     [NoCache]
-    public class IdentityTokenValidationController : ApiController
+    internal class IdentityTokenValidationController : ApiController
     {
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
         private readonly TokenValidator _validator;

--- a/source/Core/Endpoints/Connect/RevocationEndpointController.cs
+++ b/source/Core/Endpoints/Connect/RevocationEndpointController.cs
@@ -39,7 +39,7 @@ namespace Thinktecture.IdentityServer.Core.Endpoints
     [EditorBrowsable(EditorBrowsableState.Never)]
     [RoutePrefix(Constants.RoutePaths.Oidc.Revocation)]
     [NoCache]
-    public class RevocationEndpointController : ApiController
+    internal class RevocationEndpointController : ApiController
     {
         private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
         

--- a/source/Core/Endpoints/Connect/TokenEndpointController.cs
+++ b/source/Core/Endpoints/Connect/TokenEndpointController.cs
@@ -40,7 +40,7 @@ namespace Thinktecture.IdentityServer.Core.Endpoints
     [RoutePrefix(Constants.RoutePaths.Oidc.Token)]
     [NoCache]
     [PreventUnsupportedRequestMediaTypes(allowFormUrlEncoded: true)]
-    public class TokenEndpointController : ApiController
+    internal class TokenEndpointController : ApiController
     {
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
 

--- a/source/Core/Endpoints/Connect/UserInfoEndpointController.cs
+++ b/source/Core/Endpoints/Connect/UserInfoEndpointController.cs
@@ -39,7 +39,7 @@ namespace Thinktecture.IdentityServer.Core.Endpoints
     [EditorBrowsable(EditorBrowsableState.Never)]
     [RoutePrefix(Constants.RoutePaths.Oidc.UserInfo)]
     [NoCache]
-    public class UserInfoEndpointController : ApiController
+    internal class UserInfoEndpointController : ApiController
     {
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
 

--- a/source/Core/Endpoints/CspReportController.cs
+++ b/source/Core/Endpoints/CspReportController.cs
@@ -32,7 +32,7 @@ namespace Thinktecture.IdentityServer.Core.Endpoints
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
     [HostAuthentication(Constants.PrimaryAuthenticationType)]
-    public class CspReportController : ApiController
+    internal class CspReportController : ApiController
     {
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
 

--- a/source/Core/Endpoints/WelcomeController.cs
+++ b/source/Core/Endpoints/WelcomeController.cs
@@ -27,7 +27,7 @@ using Thinktecture.IdentityServer.Core.Results;
 namespace Thinktecture.IdentityServer.Core.Endpoints
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class WelcomeController : ApiController
+    internal class WelcomeController : ApiController
     {
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
 


### PR DESCRIPTION
WebApi by default does full AppDomain assembly scanning for controllers, here we just scan our own assembly.

This also means the controllers can be internal types. Ctors will need to remain public for container/di reasons.

This probably gives you scope to make more types internal that you were forced to make public because of the public controllers... I'll leave that to you :smile: 