### PR TITLE
implemented paging in ITransientDataRepository

### DIFF
--- a/source/Core/Services/Default/TokenMetadataPermissionsStoreAdapter.cs
+++ b/source/Core/Services/Default/TokenMetadataPermissionsStoreAdapter.cs
@@ -24,11 +24,11 @@ namespace Thinktecture.IdentityServer.Core.Services.Default
 {
     internal class TokenMetadataPermissionsStoreAdapter : IPermissionsStore
     {
-        readonly Func<string, Task<IEnumerable<ITokenMetadata>>> get;
+        readonly Func<string, int?, int?, Task<IEnumerable<ITokenMetadata>>> get;
         readonly Func<string, string, Task> delete;
 
         public TokenMetadataPermissionsStoreAdapter(
-            Func<string, Task<IEnumerable<ITokenMetadata>>> get, 
+            Func<string, int?, int?, Task<IEnumerable<ITokenMetadata>>> get, 
             Func<string, string, Task> delete)
         {
             if (get == null) throw new ArgumentNullException("get");

--- a/source/Core/Services/ITransientDataRepository.cs
+++ b/source/Core/Services/ITransientDataRepository.cs
@@ -53,8 +53,10 @@ namespace Thinktecture.IdentityServer.Core.Services
         /// Retrieves all data for a subject identifier.
         /// </summary>
         /// <param name="subject">The subject identifier.</param>
+        /// <param name="offset">Amount of tokens to skip. Defaults to none.</param>
+        /// <param name="take">Maximum amount of tokens to return. Defaults to all.</param>
         /// <returns>A list of token metadata</returns>
-        Task<IEnumerable<ITokenMetadata>> GetAllAsync(string subject);
+        Task<IEnumerable<ITokenMetadata>> GetAllAsync(string subject, int? offset=null, int? take=null);
 
         /// <summary>
         /// Revokes all data for a client and subject id combination.

--- a/source/Core/Services/InMemory/InMemoryAuthorizationCodeStore.cs
+++ b/source/Core/Services/InMemory/InMemoryAuthorizationCodeStore.cs
@@ -76,15 +76,25 @@ namespace Thinktecture.IdentityServer.Core.Services.InMemory
         /// Retrieves all data for a subject identifier.
         /// </summary>
         /// <param name="subject">The subject identifier.</param>
+        /// <param name="offset">Amount of tokens to skip. Defaults to none.</param>
+        /// <param name="take">Maximum amount of tokens to return. Defaults to all.</param>
         /// <returns>
         /// A list of token metadata
         /// </returns>
-        public Task<IEnumerable<ITokenMetadata>> GetAllAsync(string subject)
+        public Task<IEnumerable<ITokenMetadata>> GetAllAsync(string subject, int? offset=null, int? take=null)
         {
             var query =
                 from item in _repository
                 where item.Value.SubjectId == subject
                 select item.Value;
+            if (offset.HasValue)
+            {
+                query = query.Skip(offset.Value);
+            }
+            if (take.HasValue)
+            {
+                query = query.Take(take.Value);
+            }
             var list = query.ToArray();
             return Task.FromResult(list.Cast<ITokenMetadata>());
         }

--- a/source/Core/Services/InMemory/InMemoryRefreshTokenStore.cs
+++ b/source/Core/Services/InMemory/InMemoryRefreshTokenStore.cs
@@ -76,15 +76,25 @@ namespace Thinktecture.IdentityServer.Core.Services.InMemory
         /// Retrieves all data for a subject identifier.
         /// </summary>
         /// <param name="subject">The subject identifier.</param>
+        /// <param name="offset">Amount of tokens to skip. Defaults to none.</param>
+        /// <param name="take">Maximum amount of tokens to return. Defaults to all.</param>
         /// <returns>
         /// A list of token metadata
         /// </returns>
-        public Task<IEnumerable<ITokenMetadata>> GetAllAsync(string subject)
+        public Task<IEnumerable<ITokenMetadata>> GetAllAsync(string subject, int? offset=null, int? take=null)
         {
             var query =
                 from item in _repository
                 where item.Value.SubjectId == subject
                 select item.Value;
+            if (offset.HasValue)
+            {
+                query = query.Skip(offset.Value);
+            }
+            if (take.HasValue)
+            {
+                query = query.Take(take.Value);
+            }
             var list = query.ToArray();
             return Task.FromResult(list.Cast<ITokenMetadata>());
         }

--- a/source/Core/Services/InMemory/InMemoryTokenHandleStore.cs
+++ b/source/Core/Services/InMemory/InMemoryTokenHandleStore.cs
@@ -75,15 +75,25 @@ namespace Thinktecture.IdentityServer.Core.Services.InMemory
         /// Retrieves all data for a subject identifier.
         /// </summary>
         /// <param name="subject">The subject identifier.</param>
+        /// <param name="offset">Amount of tokens to skip. Defaults to none.</param>
+        /// <param name="take">Maximum amount of tokens to return. Defaults to all.</param>
         /// <returns>
         /// A list of token metadata
         /// </returns>
-        public Task<IEnumerable<ITokenMetadata>> GetAllAsync(string subject)
+        public Task<IEnumerable<ITokenMetadata>> GetAllAsync(string subject,int? offset=null, int? take=null)
         {
             var query =
                 from item in _repository
                 where item.Value.SubjectId == subject
                 select item.Value;
+            if (offset.HasValue)
+            {
+                query = query.Skip(offset.Value);
+            }
+            if (take.HasValue)
+            {
+                query = query.Take(take.Value);
+            }
             var list = query.ToArray();
             return Task.FromResult(list.Cast<ITokenMetadata>());
         }


### PR DESCRIPTION
So this is a work in progress as I was trying to figure out how to add paging but I soon started to see it go gown a rabbit hole and would alter a lot of calls. My idea was to keep the default behavior available, hence the nullable parameters, but allow for paging when sensible.

I think this should be included, I was considering switching an app that I have to currently runs on a custom (OAuth2-ish) solution based on JWT to IdentityServer but we so far have tens of thousands of refresh tokens and i'd feel wary of loading all this records at once. 

Is a PR like this welcome? If so, i'll continue to adapt the other methods and finish it.

It fixes issue #853 