### PR TITLE
Added the ability for custom code logging in to Identity Server (conceptual)

### DIFF
--- a/source/Core/Core.csproj
+++ b/source/Core/Core.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Extensions\IdentityServerOptionsExtensions.cs" />
     <Compile Include="Extensions\LoginPageLinkExtensions.cs" />
     <Compile Include="Extensions\X509Certificate2Extensions.cs" />
+    <Compile Include="IdentityServerLogin.cs" />
     <Compile Include="Logging\RequestResponseLogger.cs" />
     <Compile Include="Configuration\LoginPageLink.cs" />
     <Compile Include="Events\Base\EventContext.cs" />

--- a/source/Core/IdentityServerLogin.cs
+++ b/source/Core/IdentityServerLogin.cs
@@ -12,6 +12,8 @@ using AuthenticateResult = Thinktecture.IdentityServer.Core.Models.AuthenticateR
 
 namespace Thinktecture.IdentityServer.Core
 {
+    using System.Collections.Generic;
+
     /// <summary>
     /// Provides a means to login to Identity Server from custom code running on the host.
     /// This is particularly useful for scenarios where you want to log a user in a way that is
@@ -25,10 +27,10 @@ namespace Thinktecture.IdentityServer.Core
 
         private readonly LifetimeScope autofacScope;
 
-        public IdentityServerLogin(IOwinContext owinContext)
+        public IdentityServerLogin(IDictionary<string, object> environment)
         {
-            this.owinContext = owinContext;
-            this.autofacScope = GetAutofacScope(owinContext);
+            this.owinContext = new OwinContext(environment);
+            this.autofacScope = GetAutofacScope(this.owinContext);
         }
 
         /// <summary>
@@ -69,7 +71,7 @@ namespace Thinktecture.IdentityServer.Core
 
         /// <summary>
         /// This does the mechanics of getting IdSrv to log you in and set an auth cookie
-        /// Basically copy & paste from the auth controller
+        /// Basically copy and paste from the auth controller
         /// This does deliberately not allow persistent cookies
         /// </summary>
         private void SetTheIdSrvAuthCookie(AuthenticateResult p)

--- a/source/Core/IdentityServerLogin.cs
+++ b/source/Core/IdentityServerLogin.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Autofac.Core.Lifetime;
+using Microsoft.Owin;
+using Thinktecture.IdentityServer.Core.Configuration.Hosting;
+using Thinktecture.IdentityServer.Core.Logging;
+using Thinktecture.IdentityServer.Core.Models;
+using Thinktecture.IdentityServer.Core.Services;
+using Microsoft.Owin.Security;
+using AuthenticateResult = Thinktecture.IdentityServer.Core.Models.AuthenticateResult;
+
+namespace Thinktecture.IdentityServer.Core
+{
+    /// <summary>
+    /// Provides a means to login to Identity Server from custom code running on the host.
+    /// This is particularly useful for scenarios where you want to log a user in a way that is
+    /// not directly supported by IdentityServer, for example IdP-initiated SSO.
+    /// </summary>
+    public class IdentityServerLogin
+    {
+        private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
+
+        private readonly IOwinContext owinContext;
+
+        private readonly LifetimeScope autofacScope;
+
+        public IdentityServerLogin(IOwinContext owinContext)
+        {
+            this.owinContext = owinContext;
+            this.autofacScope = GetAutofacScope(owinContext);
+        }
+
+        /// <summary>
+        /// This will validate the externalIdentity against the UserService and will set the appropriate authentication cookies
+        /// </summary>
+        /// <param name="externalIdentity"></param>
+        /// <returns></returns>
+        public async Task<AuthenticateResult> LogInToIdentityServer(ExternalIdentity externalIdentity)
+        {
+            // Most of the code in this method is duplicated in AuthenticationController.LoginExternalCallback
+            // However, due to the different use case it is tricky to refactor this code to be shared
+
+            Logger.InfoFormat("custom login to IdSrv with external user provider: {0}, provider ID: {1}", externalIdentity.Provider, externalIdentity.ProviderId);
+            var userService = GetUserService();
+            var authResult = await userService.AuthenticateExternalAsync(externalIdentity, new SignInMessage());
+
+            if (authResult == null)
+            {
+                Logger.Warn("custom login to IdSrv: user service failed to authenticate external identity");
+                throw new Exception("The user service failed to authenticate external identity"); // TODO: There may be a more approprite exception to use?
+            }
+
+            if (authResult.IsError)
+            {
+                Logger.WarnFormat("custom login to IdSrv: user service returned error message: {0}", authResult.ErrorMessage);
+                return authResult;
+            }
+
+            Logger.Info("custom login to IdSrv: External identity successfully validated by user service");
+
+            // Get IdentityServer to set an authentication cookie
+            SetTheIdSrvAuthCookie(authResult);
+            this.GetTheSessionCookie().IssueSessionId();
+            Logger.Info("custom login to IdSrv: Completed issuing session cookie");
+
+            return authResult;
+        }
+
+        /// <summary>
+        /// This does the mechanics of getting IdSrv to log you in and set an auth cookie
+        /// Basically copy & paste from the auth controller
+        /// This does deliberately not allow persistent cookies
+        /// </summary>
+        private void SetTheIdSrvAuthCookie(AuthenticateResult p)
+        {
+            var user = IdentityServerPrincipal.CreateFromPrincipal(p.User, Constants.PrimaryAuthenticationType);
+            owinContext.Authentication.SignOut(
+                Constants.PrimaryAuthenticationType,
+                Constants.ExternalAuthenticationType,
+                Constants.PartialSignInAuthenticationType);
+
+            var props = new AuthenticationProperties();
+            var id = user.Identities.First();
+
+            owinContext.Authentication.SignIn(props, id);
+        }
+
+        private SessionCookie GetTheSessionCookie()
+        {
+            var sessionCookie = autofacScope.GetService(typeof(SessionCookie)) as SessionCookie;
+            if (sessionCookie == null)
+            {
+                Logger.Warn("custom user login failed to retrieve the SessionCookie from the dependency resolver");
+                throw new Exception("Failed to get the SessionCookie from the dependency resolver");
+            }
+            return sessionCookie;
+        }
+
+        /// <summary>
+        /// Horrible hack to get the IUserService
+        /// Would like to replace with a cleaner way but not sure how that would be possible
+        /// </summary>
+        /// <returns></returns>
+        private IUserService GetUserService()
+        {
+            var userService = autofacScope.GetService(typeof(IUserService)) as IUserService;
+            if (userService == null)
+            {
+                Logger.Warn("custom user login failed to retrieve the IUserService from the dependency resolver");
+                throw new Exception("Failed to get IUserService from the dependency resolver");
+            }
+            return userService;
+        }
+
+        private static LifetimeScope GetAutofacScope(IOwinContext owinContext)
+        {
+            var autofacScope = owinContext.Environment["idsrv:AutofacScope"] as LifetimeScope;
+
+            if (autofacScope == null)
+            {
+                Logger.Warn("custom user login failed to retrieve autofac from the IOwinContext");
+                throw new Exception("Unable to get the autofacscope");
+            }
+            return autofacScope;
+        }
+    }
+}

--- a/source/Tests/UnitTests/ClassVisibilityTests.cs
+++ b/source/Tests/UnitTests/ClassVisibilityTests.cs
@@ -51,7 +51,11 @@ namespace Thinktecture.IdentityServer.Tests
             var errors = new List<string>();
             foreach (var type in assembly.GetExportedTypes())
             {
-                errors.AddRange(CheckConstructor(type));
+                //IdentityServerLogin provides an external hook for logging in and takes an IOwinContext
+                if (type != typeof(IdentityServerLogin))
+                {
+                    errors.AddRange(CheckConstructor(type));
+                }
                 //API controllers need to be public if we don't want to rewrite autofac/webapi controller discovery
                 if (type.BaseType != typeof (ApiController))
                 {

--- a/source/Tests/UnitTests/ClassVisibilityTests.cs
+++ b/source/Tests/UnitTests/ClassVisibilityTests.cs
@@ -51,11 +51,7 @@ namespace Thinktecture.IdentityServer.Tests
             var errors = new List<string>();
             foreach (var type in assembly.GetExportedTypes())
             {
-                //IdentityServerLogin provides an external hook for logging in and takes an IOwinContext
-                if (type != typeof(IdentityServerLogin))
-                {
-                    errors.AddRange(CheckConstructor(type));
-                }
+                errors.AddRange(CheckConstructor(type));
                 //API controllers need to be public if we don't want to rewrite autofac/webapi controller discovery
                 if (type.BaseType != typeof (ApiController))
                 {


### PR DESCRIPTION
 - Added a class to IdentityServer (IdentityServerLogin) that custom code running on the host can use to log in to to log in to IdentityServer and setting authentication cookies by passing in an ExternalIdentity.

#833

*Notes*
** Please feel free to reject this PR, I won't be offended, promise ;) **
I do understand that this issue has not been agreed to be implemented and I also think that my implementation here leaves a number of things to be desired, not least the naming and error handling, which I don't think is quite in keeping with the rest of the project (I wasn't quite sure about where to put this or the best way to handle the errors).
I wanted to show an example implementation and provide a boundary around what I think it needs to do - which isn't a huge amount. Of course, the awful hacks around autofac that are required may make this a bit of a maintenance headache down the road.

This commit does not have unit tests as the code works directly with autofac which makes it rather complicated.

*Usage*
This sample middleware shows how to use it. Note that if using app.Map to load IdSrv, this middleware must be loaded in the same app.Map as IdSrv to make sure the cookie path is correct and that autofac is available:

    public class DummyIdpMiddleWare
    {
        private readonly Func<IDictionary<string, object>, Task> next;

        public DummyIdpMiddleWare(Func<IDictionary<string, object>, Task> next)
        {
            this.next = next;
        }

        public async Task Invoke(IDictionary<string, object> environment)
        {
            var context = new Microsoft.Owin.OwinContext(environment);
            if (context.Request.Path.StartsWithSegments(new PathString("/secretsquirrel")))
            {
                // You should also limit to POSTs probably
                // Here you should evaluate the user input to make sure it is all correct, like checking a SAML token or whatever
                // If you felt particularly foolish you could even use Basic Auth here :) Or two-legged oAuth 1 for custom integrations etc
                
                var externalLogin = new ExternalIdentity()
                {
                    ProviderId = "secretSquirrelId",
                    Provider = "Secret Squirrel",
                    Claims = new List<Claim>
                                                         {
                                                            new Claim(Constants.ClaimTypes.Name, "Billy Bob"),
                                                            new Claim(Constants.ClaimTypes.Role, "Boss")
                                                         }
                };
                // This is the integration point to IdSrv - this will set an auth cookie
                var idSrvLogin = new IdentityServerLogin(environment);
                var result = await idSrvLogin.LogInToIdentityServer(externalLogin);

                // TODO: Check the result here

                // Redirect the user to the Relying Party, which will send the user straight back to IdSrv to get an OIDC token
                context.Response.Redirect("https://localhost:44303/Home/About");
                // TODO: Consider returning here instead of invoking the next middleware
            }
            await this.next.Invoke(environment);
        }
    }

<!---
@huboard:{"order":40.75,"milestone_order":930,"custom_state":""}
-->
