### PR TITLE
Remove Transitive Dependency on System.Web

### DIFF
--- a/source/Core/Core.csproj
+++ b/source/Core/Core.csproj
@@ -46,9 +46,6 @@
     <DocumentationFile>..\..\build\Thinktecture.IdentityServer.Core.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AntiXssLibrary">
-      <HintPath>..\packages\AntiXSS.4.3.0\lib\net40\AntiXssLibrary.dll</HintPath>
-    </Reference>
     <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
@@ -56,9 +53,6 @@
     <Reference Include="Autofac.Integration.WebApi, Version=3.4.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Autofac.WebApi2.3.4.0\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
-    </Reference>
-    <Reference Include="HtmlSanitizationLibrary">
-      <HintPath>..\packages\AntiXSS.4.3.0\lib\net40\HtmlSanitizationLibrary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -165,6 +159,18 @@
     <Compile Include="Extensions\IdentityServerOptionsExtensions.cs" />
     <Compile Include="Extensions\LoginPageLinkExtensions.cs" />
     <Compile Include="Extensions\X509Certificate2Extensions.cs" />
+    <Compile Include="Internal\AntiXssLibrary\CodeCharts\CodeChartHelper.cs" />
+    <Compile Include="Internal\AntiXssLibrary\CodeCharts\Lower.cs" />
+    <Compile Include="Internal\AntiXssLibrary\CodeCharts\LowerMiddle.cs" />
+    <Compile Include="Internal\AntiXssLibrary\CodeCharts\Middle.cs" />
+    <Compile Include="Internal\AntiXssLibrary\CodeCharts\Upper.cs" />
+    <Compile Include="Internal\AntiXssLibrary\CodeCharts\UpperMiddle.cs" />
+    <Compile Include="Internal\AntiXssLibrary\EncoderUtil.cs" />
+    <Compile Include="Internal\AntiXssLibrary\SafeList.cs" />
+    <Compile Include="Internal\AntiXssLibrary\UnicodeCharacterEncoder.cs" />
+    <Compile Include="Internal\AntiXssLibrary\CodeCharts.cs" />
+    <Compile Include="Internal\AntiXssLibrary\Encoder.cs" />
+    <Compile Include="Internal\AntiXssLibrary\Utf16StringReader.cs" />
     <Compile Include="Logging\RequestResponseLogger.cs" />
     <Compile Include="Configuration\LoginPageLink.cs" />
     <Compile Include="Events\Base\EventContext.cs" />

--- a/source/Core/Internal/AntiXssLibrary/CodeCharts.cs
+++ b/source/Core/Internal/AntiXssLibrary/CodeCharts.cs
@@ -1,0 +1,969 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CodeCharts.cs" company="Microsoft Corporation">
+//   Copyright (c) 2008, 2009, 2010 All Rights Reserved, Microsoft Corporation
+//
+//   This source is subject to the Microsoft Permissive License.
+//   Please see the License.txt file for more information.
+//   All other rights reserved.
+//
+//   THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+//   KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//   IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//   PARTICULAR PURPOSE.
+//
+// </copyright>
+// <summary>
+//   Enumerations for the various printable code tables within the Unicode UTF space.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+// ReSharper disable CheckNamespace
+namespace Microsoft.Security.Application
+    // ReSharper restore CheckNamespace
+{
+    using System;
+
+    /// <summary>
+    /// Values for the lowest section of the UTF8 Unicode code tables, from U0000 to U0FFF.
+    /// </summary>
+    [Flags]
+    public enum LowerCodeCharts : long
+    {
+        /// <summary>
+        /// No code charts from the lower region of the Unicode tables are safe-listed.
+        /// </summary>
+        None                                        = 0,
+
+        /// <summary>
+        /// The Basic Latin code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0000.pdf</remarks>
+        BasicLatin                                  = 1 << 0x00,
+        
+        /// <summary>
+        /// The C1 Controls and Latin-1 Supplement code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0080.pdf</remarks>
+        C1ControlsAndLatin1Supplement               = 1 << 0x01,
+
+        /// <summary>
+        /// The Latin Extended-A code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0100.pdf</remarks>
+        LatinExtendedA                              = 1 << 0x02,
+        
+        /// <summary>
+        /// The Latin Extended-B code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0180.pdf</remarks>
+        LatinExtendedB                              = 1 << 0x03,
+        
+        /// <summary>
+        /// The IPA Extensions code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0250.pdf</remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Ipa", Justification = "Unicode Standard")]
+        IpaExtensions                               = 1 << 0x04,
+        
+        /// <summary>
+        /// The Spacing Modifier Letters code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U02B0.pdf</remarks>
+        SpacingModifierLetters                      = 1 << 0x05,
+
+        /// <summary>
+        /// The Combining Diacritical Marks code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0300.pdf</remarks>
+        CombiningDiacriticalMarks                   = 1 << 0x06,        
+
+        /// <summary>
+        /// The Greek and Coptic code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0370.pdf</remarks>
+        GreekAndCoptic                              = 1 << 0x07,
+        
+        /// <summary>
+        /// The Cyrillic code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0400.pdf</remarks>
+        Cyrillic                                    = 1 << 0x08,
+
+        /// <summary>
+        /// The Cyrillic Supplement code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0500.pdf</remarks>
+        CyrillicSupplement                          = 1 << 0x09,
+        
+        /// <summary>
+        /// The Armenian code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0530.pdf</remarks>
+        Armenian                                    = 1 << 0x0A,
+
+        /// <summary>
+        /// The Hebrew code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0590.pdf</remarks>
+        Hebrew                                      = 1 << 0x0B,
+        
+        /// <summary>
+        /// The Arabic code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0600.pdf</remarks>
+        Arabic                                      = 1 << 0x0C,
+                
+        /// <summary>
+        /// The Syriac code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0700.pdf</remarks>
+        Syriac                                      = 1 << 0x0D,
+        
+        /// <summary>
+        /// The Arabic Supplement code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0750.pdf</remarks>
+        ArabicSupplement                            = 1 << 0x0E,
+        
+        /// <summary>
+        /// The Thaana code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0780.pdf</remarks>
+        Thaana                                      = 1 << 0x0F,
+
+        /// <summary>
+        /// The Nko code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U07C0.pdf</remarks>
+        Nko                                         = 1 << 0x10,
+        
+        /// <summary>
+        /// The Samaritan code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0800.pdf</remarks>
+        Samaritan                                   = 1 << 0x11,
+        
+        /// <summary>
+        /// The Devanagari code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0900.pdf</remarks>
+        Devanagari                                  = 1 << 0x12,
+        
+        /// <summary>
+        /// The Bengali code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0980.pdf</remarks>
+        Bengali                                     = 1 << 0x13,
+        
+        /// <summary>
+        /// The Gurmukhi code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0A00.pdf</remarks>
+        Gurmukhi                                    = 1 << 0x14,
+        
+        /// <summary>
+        /// The Gujarati code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0A80.pdf</remarks>
+        Gujarati                                    = 1 << 0x15,
+
+        /// <summary>
+        /// The Oriya code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0B00.pdf</remarks>
+        Oriya                                       = 1 << 0x16,
+        
+        /// <summary>
+        /// The Tamil code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0B80.pdf</remarks>
+        Tamil                                       = 1 << 0x17,
+
+        /// <summary>
+        /// The Telugu code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0C00.pdf</remarks>
+        Telugu                                      = 1 << 0x18,
+
+        /// <summary>
+        /// The Kannada code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0C80.pdf</remarks>
+        Kannada                                     = 1 << 0x19,
+
+        /// <summary>
+        /// The Malayalam code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0D00.pdf</remarks>
+        Malayalam                                   = 1 << 0x1A,
+
+        /// <summary>
+        /// The Sinhala code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0D80.pdf</remarks>
+        Sinhala                                     = 1 << 0x1B,
+
+        /// <summary>
+        /// The Thai code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0E00.pdf</remarks>
+        Thai                                        = 1 << 0x1C,
+
+        /// <summary>
+        /// The Lao code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0E80.pdf</remarks>
+        Lao                                         = 1 << 0x1D,
+
+        /// <summary>
+        /// The Tibetan code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U0F00.pdf</remarks>
+        Tibetan                                     = 1 << 0x1E,
+
+        /// <summary>
+        /// The default code tables marked as safe on initialisation.
+        /// </summary>
+        Default = BasicLatin | C1ControlsAndLatin1Supplement | LatinExtendedA | LatinExtendedB | SpacingModifierLetters | IpaExtensions | CombiningDiacriticalMarks
+    }
+
+    /// <summary>
+    /// Values for the lower-mid section of the UTF8 Unicode code tables, from U1000 to U1EFF.
+    /// </summary>
+    [Flags]
+    public enum LowerMidCodeCharts : long
+    {
+        /// <summary>
+        /// No code charts from the lower-mid region of the Unicode tables are safe-listed.
+        /// </summary>
+        None                                        = 0,
+
+        /// <summary>
+        /// The Myanmar code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1000.pdf</remarks>
+        Myanmar                                      = 1 << 0x00,
+
+        /// <summary>
+        /// The Georgian code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U10A0.pdf</remarks>
+        Georgian                                    = 1 << 0x01,
+
+        /// <summary>
+        /// The Hangul Jamo code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1100.pdf</remarks>
+        HangulJamo                                  = 1 << 0x02,
+
+        /// <summary>
+        /// The Ethiopic code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1200.pdf</remarks>
+        Ethiopic                                    = 1 << 0x03,
+
+        /// <summary>
+        /// The Ethiopic supplement code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1380.pdf</remarks>
+        EthiopicSupplement                          = 1 << 0x04,
+
+        /// <summary>
+        /// The Cherokee code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U13A0.pdf</remarks>
+        Cherokee                                    = 1 << 0x05,
+
+        /// <summary>
+        /// The Unified Canadian Aboriginal Syllabics code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1400.pdf</remarks>
+        UnifiedCanadianAboriginalSyllabics          = 1 << 0x06,
+        
+        /// <summary>
+        /// The Ogham code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1680.pdf</remarks>
+        Ogham                                       = 1 << 0x07,
+                        
+        /// <summary>
+        /// The Runic code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U16A0.pdf</remarks>
+        Runic                                       = 1 << 0x08,
+
+        /// <summary>
+        /// The Tagalog code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1700.pdf</remarks>
+        Tagalog                                     = 1 << 0x09,
+
+        /// <summary>
+        /// The Hanunoo code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1720.pdf</remarks>
+        Hanunoo                                     = 1 << 0x0A,
+
+        /// <summary>
+        /// The Buhid code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1740.pdf</remarks>
+        Buhid                                       = 1 << 0x0B,
+
+        /// <summary>
+        /// The Tagbanwa code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1760.pdf</remarks>
+        Tagbanwa                                    = 1 << 0x0C,
+
+        /// <summary>
+        /// The Khmer code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1780.pdf</remarks>
+        Khmer                                       = 1 << 0x0D,
+
+        /// <summary>
+        /// The Mongolian code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1800.pdf</remarks>
+        Mongolian                                   = 1 << 0x0E,
+                
+        /// <summary>
+        /// The Unified Canadian Aboriginal Syllabics Extended code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U18B0.pdf</remarks>
+        UnifiedCanadianAboriginalSyllabicsExtended  = 1 << 0x0F,
+
+        /// <summary>
+        /// The Limbu code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1900.pdf</remarks>
+        Limbu                                       = 1 << 0x10,
+        
+        /// <summary>
+        /// The Tai Le code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1950.pdf</remarks>
+        TaiLe                                       = 1 << 0x11,
+
+        /// <summary>
+        /// The New Tai Lue code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1980.pdf</remarks>
+        NewTaiLue                                   = 1 << 0x12,
+
+        /// <summary>
+        /// The Khmer Symbols code table
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U19E0.pdf</remarks>
+        KhmerSymbols                                = 1 << 0x13,
+
+        /// <summary>
+        /// The Buginese code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1A00.pdf</remarks>
+        Buginese                                    = 1 << 0x14,
+        
+        /// <summary>
+        /// The Tai Tham code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1A20.pdf</remarks>
+        TaiTham                                     = 1 << 0x15,
+
+        /// <summary>
+        /// The Balinese code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1B00.pdf</remarks>
+        Balinese                                    = 1 << 0x16,
+
+        /// <summary>
+        /// The Sudanese code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1B80.pdf</remarks>
+        Sudanese                                    = 1 << 0x17,
+        
+        /// <summary>
+        /// The Lepcha code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1C00.pdf</remarks>
+        Lepcha                                      = 1 << 0x18,
+        
+        /// <summary>
+        /// The Ol Chiki code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1C50.pdf</remarks>
+        OlChiki                                     = 1 << 0x19,
+        
+        /// <summary>
+        /// The Vedic Extensions code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1CD0.pdf</remarks>
+        VedicExtensions                             = 1 << 0x1A,
+        
+        /// <summary>
+        /// The Phonetic Extensions code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1D00.pdf</remarks>
+        PhoneticExtensions                          = 1 << 0x1B,
+        
+        /// <summary>
+        /// The Phonetic Extensions Supplement code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1D80.pdf</remarks>
+        PhoneticExtensionsSupplement                = 1 << 0x1C,        
+        
+        /// <summary>
+        /// The Combining Diacritical Marks Supplement code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1DC0.pdf</remarks>        
+        CombiningDiacriticalMarksSupplement         = 1 << 0x1D,
+
+        /// <summary>
+        /// The Latin Extended Additional code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1E00.pdf</remarks>
+        LatinExtendedAdditional                     = 1 << 0x1E
+    }
+
+    /// <summary>
+    /// Values for the middle section of the UTF8 Unicode code tables, from U1F00 to U2DDF
+    /// </summary>
+    [Flags]
+    public enum MidCodeCharts : long
+    {
+        /// <summary>
+        /// No code charts from the lower region of the Unicode tables are safe-listed.
+        /// </summary>
+        None                                        = 0,
+        
+        /// <summary>
+        /// The Greek Extended code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U1F00.pdf</remarks>
+        GreekExtended                               = 1 << 0x00,
+
+        /// <summary>
+        /// The General Punctuation code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2000.pdf</remarks>
+        GeneralPunctuation                          = 1 << 0x01,
+        
+        /// <summary>
+        /// The Superscripts and Subscripts code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2070.pdf</remarks>
+        SuperscriptsAndSubscripts                   = 1 << 0x02,
+        
+        /// <summary>
+        /// The Currency Symbols code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U20A0.pdf</remarks>
+        CurrencySymbols                             = 1 << 0x03,
+
+        /// <summary>
+        /// The Combining Diacritical Marks for Symbols code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U20D0.pdf</remarks>
+        CombiningDiacriticalMarksForSymbols         = 1 << 0x04,
+
+        /// <summary>
+        /// The Letterlike Symbols code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2100.pdf</remarks>
+        LetterlikeSymbols                           = 1 << 0x05,
+
+        /// <summary>
+        /// The Number Forms code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2150.pdf</remarks>
+        NumberForms                                 = 1 << 0x06,
+
+        /// <summary>
+        /// The Arrows code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2190.pdf</remarks>
+        Arrows                                      = 1 << 0x07,
+
+        /// <summary>
+        /// The Mathematical Operators code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2200.pdf</remarks>
+        MathematicalOperators                       = 1 << 0x08,
+        
+        /// <summary>
+        /// The Miscellaneous Technical code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2300.pdf</remarks>
+        MiscellaneousTechnical                      = 1 << 0x09,
+
+        /// <summary>
+        /// The Control Pictures code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2400.pdf</remarks>
+        ControlPictures                             = 1 << 0x0A,
+
+        /// <summary>
+        /// The Optical Character Recognition table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2440.pdf</remarks>
+        OpticalCharacterRecognition                 = 1 << 0x0B,
+
+        /// <summary>
+        /// The Enclosed Alphanumeric code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2460.pdf</remarks>
+        EnclosedAlphanumerics                       = 1 << 0x0C,
+
+        /// <summary>
+        /// The Box Drawing code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2500.pdf</remarks>
+        BoxDrawing                                  = 1 << 0x0D,
+
+        /// <summary>
+        /// The Block Elements code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2580.pdf</remarks>
+        BlockElements                               = 1 << 0x0E,
+
+        /// <summary>
+        /// The Geometric Shapes code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U25A0.pdf</remarks>
+        GeometricShapes                             = 1 << 0x0F,
+
+        /// <summary>
+        /// The Miscellaneous Symbols code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2600.pdf</remarks>
+        MiscellaneousSymbols                        = 1 << 0x10,
+
+        /// <summary>
+        /// The Dingbats code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2700.pdf</remarks>
+        Dingbats                                    = 1 << 0x11,
+        
+        /// <summary>
+        /// The Miscellaneous Mathematical Symbols-A code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U27C0.pdf</remarks>
+        MiscellaneousMathematicalSymbolsA           = 1 << 0x12,
+        
+        /// <summary>
+        /// The Supplemental Arrows-A code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U27F0.pdf</remarks>
+        SupplementalArrowsA                         = 1 << 0x13,
+
+        /// <summary>
+        /// The Braille Patterns code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2800.pdf</remarks>
+        BraillePatterns                             = 1 << 0x14,
+        
+        /// <summary>
+        /// The Supplemental Arrows-B code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2900.pdf</remarks>
+        SupplementalArrowsB                         = 1 << 0x15,
+
+        /// <summary>
+        /// The Miscellaneous Mathematical Symbols-B code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2980.pdf</remarks>                
+        MiscellaneousMathematicalSymbolsB           = 1 << 0x16,
+                
+        /// <summary>
+        /// The Supplemental Mathematical Operators code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2A00.pdf</remarks>
+        SupplementalMathematicalOperators           = 1 << 0x17,
+
+        /// <summary>
+        /// The Miscellaneous Symbols and Arrows code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2B00.pdf</remarks>        
+        MiscellaneousSymbolsAndArrows               = 1 << 0x18,
+        
+        /// <summary>
+        /// The Glagolitic code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2C00.pdf</remarks>
+        Glagolitic                                  = 1 << 0x19,
+        
+        /// <summary>
+        /// The Latin Extended-C code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2C60.pdf</remarks>        
+        LatinExtendedC                              = 1 << 0x1A,
+        
+        /// <summary>
+        /// The Coptic code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2C80.pdf</remarks>
+        Coptic                                      = 1 << 0x1B,
+        
+        /// <summary>
+        /// The Georgian Supplement code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2D00.pdf</remarks>
+        GeorgianSupplement                          = 1 << 0x1C,
+
+        /// <summary>
+        /// The Tifinagh code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2D30.pdf</remarks>
+        Tifinagh                                    = 1 << 0x1D,
+
+        /// <summary>
+        /// The Ethiopic Extended code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2D80.pdf</remarks>
+        EthiopicExtended                            = 1 << 0x0E,    
+    }
+
+    /// <summary>
+    /// Values for the upper middle section of the UTF8 Unicode code tables, from U2DE0 to UA8DF
+    /// </summary>
+    [Flags]
+    public enum UpperMidCodeCharts : long
+    {
+        /// <summary>
+        /// No code charts from the lower region of the Unicode tables are safe-listed.
+        /// </summary>
+        None                                        = 0,                  
+        
+        /// <summary>
+        /// The Cyrillic Extended-A code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2DE0.pdf</remarks>
+        CyrillicExtendedA                           = 1 << 0x00,
+        
+        /// <summary>
+        /// The Supplemental Punctuation code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2E00.pdf</remarks>
+        SupplementalPunctuation                     = 1 << 0x01,
+        
+        /// <summary>
+        /// The CJK Radicials Supplement code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2E80.pdf</remarks>
+        CjkRadicalsSupplement                       = 1 << 0x02,
+        
+        /// <summary>
+        /// The Kangxi Radicials code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2F00.pdf</remarks>
+        KangxiRadicals                              = 1 << 0x03,
+        
+        /// <summary>
+        /// The Ideographic Description Characters code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U2FF0.pdf</remarks>
+        IdeographicDescriptionCharacters            = 1 << 0x04,
+        
+        /// <summary>
+        /// The CJK Symbols and Punctuation code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U3000.pdf</remarks>
+        CjkSymbolsAndPunctuation                    = 1 << 0x05,
+
+        /// <summary>
+        /// The Hiragana code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U3040.pdf</remarks>
+        Hiragana                                    = 1 << 0x06,
+        
+        /// <summary>
+        /// The Katakana code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U30A0.pdf</remarks>
+        Katakana                                    = 1 << 0x07,
+
+        /// <summary>
+        /// The Bopomofo code table.
+        /// <seealso cref="BopomofoExtended"/>
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U3100.pdf</remarks>
+        Bopomofo                                    = 1 << 0x08,
+
+        /// <summary>
+        /// The Hangul Compatbility Jamo code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U3130.pdf</remarks>
+        HangulCompatibilityJamo                     = 1 << 0x09,
+
+        /// <summary>
+        /// The Kanbun code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U3190.pdf</remarks>
+        Kanbun                                      = 1 << 0x0A,
+
+        /// <summary>
+        /// The Bopomofu Extended code table.
+        /// <seealso cref="Bopomofo"/>
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U31A0.pdf</remarks>
+        BopomofoExtended                            = 1 << 0x0B,
+
+        /// <summary>
+        /// The CJK Strokes code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U31C0.pdf</remarks>
+        CjkStrokes                                  = 1 << 0x0C,
+        
+        /// <summary>
+        /// The Katakana Phonetic Extensoins code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U31F0.pdf</remarks>
+        KatakanaPhoneticExtensions                  = 1 << 0x0D,
+
+        /// <summary>
+        /// The Enclosed CJK Letters and Months code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U3200.pdf</remarks>
+        EnclosedCjkLettersAndMonths                 = 1 << 0x0E,
+
+        /// <summary>
+        /// The CJK Compatibility code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U3300.pdf</remarks>
+        CjkCompatibility                            = 1 << 0x0F,
+
+        /// <summary>
+        /// The CJK Unified Ideographs Extension A code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U3400.pdf</remarks>
+        CjkUnifiedIdeographsExtensionA              = 1 << 0x10,
+
+        /// <summary>
+        /// The Yijing Hexagram Symbols code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U4DC0.pdf</remarks>
+        YijingHexagramSymbols                       = 1 << 0x11,
+        
+        /// <summary>
+        /// The CJK Unified Ideographs code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/U4E00.pdf</remarks>
+        CjkUnifiedIdeographs                        = 1 << 0x12,
+        
+        /// <summary>
+        /// The Yi Syllables code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA000.pdf</remarks>
+        YiSyllables                                 = 1 << 0x13,
+
+        /// <summary>
+        /// The Yi Radicals code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA490.pdf</remarks>
+        YiRadicals                                  = 1 << 0x14,
+
+        /// <summary>
+        /// The Lisu code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA4D0.pdf</remarks>        
+        Lisu                                        = 1 << 0x15,
+
+        /// <summary>
+        /// The Vai code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA500.pdf</remarks>
+        Vai                                         = 1 << 0x16,
+
+        /// <summary>
+        /// The Cyrillic Extended-B code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA640.pdf</remarks>
+        CyrillicExtendedB                           = 1 << 0x17,
+
+        /// <summary>
+        /// The Bamum code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA6A0.pdf</remarks>
+        Bamum                                       = 1 << 0x18,
+
+        /// <summary>
+        /// The Modifier Tone Letters code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA700.pdf</remarks>
+        ModifierToneLetters                         = 1 << 0x19,
+
+        /// <summary>
+        /// The Latin Extended-D code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA720.pdf</remarks>
+        LatinExtendedD                              = 1 << 0x1A,
+
+        /// <summary>
+        /// The Syloti Nagri code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA800.pdf</remarks>
+        SylotiNagri                                 = 1 << 0x1B,
+
+        /// <summary>
+        /// The Common Indic Number Forms code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA830.pdf</remarks>
+        CommonIndicNumberForms                      = 1 << 0x1C,
+
+        /// <summary>
+        /// The Phags-pa code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA840.pdf</remarks>
+        Phagspa                                     = 1 << 0x1D,
+
+        /// <summary>
+        /// The Saurashtra code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA880.pdf</remarks>
+        Saurashtra                                  = 1 << 0x1E,
+    }
+
+    /// <summary>
+    /// Values for the upper section of the UTF8 Unicode code tables, from UA8E0 to UFFFD
+    /// </summary>
+    [Flags]
+    public enum UpperCodeCharts
+    {
+        /// <summary>
+        /// No code charts from the upper region of the Unicode tables are safe-listed.
+        /// </summary>
+        None                                        = 0,
+
+        /// <summary>
+        /// The Devanagari Extended code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA8E0.pdf</remarks>
+        DevanagariExtended                          = 1 << 0x00,
+
+        /// <summary>
+        /// The Kayah Li code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA900.pdf</remarks>
+        KayahLi                                     = 1 << 0x01,
+
+        /// <summary>
+        /// The Rejang code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA930.pdf</remarks>
+        Rejang                                      = 1 << 0x02,
+
+        /// <summary>
+        /// The Hangul Jamo Extended-A code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA960.pdf</remarks>
+        HangulJamoExtendedA                         = 1 << 0x03,
+
+        /// <summary>
+        /// The Javanese code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UA980.pdf</remarks>
+        Javanese                                    = 1 << 0x04,
+
+        /// <summary>
+        /// The Cham code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UAA00.pdf</remarks>
+        Cham                                        = 1 << 0x05,
+
+        /// <summary>
+        /// The Myanmar Extended-A code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UAA60.pdf</remarks>
+        MyanmarExtendedA                            = 1 << 0x06,
+
+        /// <summary>
+        /// The Tai Viet code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UAA80.pdf</remarks>
+        TaiViet                                     = 1 << 0x07,
+
+        /// <summary>
+        /// The Meetei Mayek code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UABC0.pdf</remarks>
+        MeeteiMayek                                 = 1 << 0x08,
+
+        /// <summary>
+        /// The Hangul Syllables code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UAC00.pdf</remarks>
+        HangulSyllables                             = 1 << 0x09,
+
+        /// <summary>
+        /// The Hangul Jamo Extended-B code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UD7B0.pdf</remarks>
+        HangulJamoExtendedB                         = 1 << 0x0A,
+        
+        /// <summary>
+        /// The CJK Compatibility Ideographs code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UF900.pdf</remarks>
+        CjkCompatibilityIdeographs                  = 1 << 0x0B,
+        
+        /// <summary>
+        /// The Alphabetic Presentation Forms code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UFB00.pdf</remarks>
+        AlphabeticPresentationForms                 = 1 << 0x0C,
+        
+        /// <summary>
+        /// The Arabic Presentation Forms-A code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UFB50.pdf</remarks>
+        ArabicPresentationFormsA                    = 1 << 0x0D,
+        
+        /// <summary>
+        /// The Variation Selectors code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UFE00.pdf</remarks>
+        VariationSelectors                          = 1 << 0x0E,
+        
+        /// <summary>
+        /// The Vertical Forms code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UFE10.pdf</remarks>
+        VerticalForms                               = 1 << 0x0F,
+        
+        /// <summary>
+        /// The Combining Half Marks code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UFE20.pdf</remarks>
+        CombiningHalfMarks                          = 1 << 0x10,
+        
+        /// <summary>
+        /// The CJK Compatibility Forms code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UFE30.pdf</remarks>
+        CjkCompatibilityForms                       = 1 << 0x11,
+        
+        /// <summary>
+        /// The Small Form Variants code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UFE50.pdf</remarks>
+        SmallFormVariants                           = 1 << 0x12,
+        
+        /// <summary>
+        /// The Arabic Presentation Forms-B code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UFE70.pdf</remarks>
+        ArabicPresentationFormsB                    = 1 << 0x13,
+        
+        /// <summary>
+        /// The half width and full width Forms code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UFF00.pdf</remarks>
+        HalfWidthAndFullWidthForms                  = 1 << 0x14,
+        
+        /// <summary>
+        /// The Specials code table.
+        /// </summary>
+        /// <remarks>http://www.unicode.org/charts/PDF/UFFF0.pdf</remarks>
+        Specials                                    = 1 << 0x15,
+    }
+}

--- a/source/Core/Internal/AntiXssLibrary/CodeCharts/CodeChartHelper.cs
+++ b/source/Core/Internal/AntiXssLibrary/CodeCharts/CodeChartHelper.cs
@@ -1,0 +1,62 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CodeChartHelper.cs" company="Microsoft Corporation">
+//   Copyright (c) 2008, 2009, 2010 All Rights Reserved, Microsoft Corporation
+//
+//   This source is subject to the Microsoft Permissive License.
+//   Please see the License.txt file for more information.
+//   All other rights reserved.
+//
+//   THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+//   KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//   IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//   PARTICULAR PURPOSE.
+//
+// </copyright>
+// <summary>
+//   Helper functions to simplify range/safe enumerations.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+// ReSharper disable CheckNamespace
+namespace Microsoft.Security.Application.CodeCharts
+    // ReSharper restore CheckNamespace
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Helper functions to simplify range/safe enumerations.
+    /// </summary>
+    internal static class CodeChartHelper
+    {
+        /// <summary>
+        /// Generates a range of numbers starting at <paramref name="min"/>, ending at <paramref name="max"/> and using any exclusions specified in the <paramref name="exclusionFilter"/>.
+        /// </summary>
+        /// <param name="min">The starting number.</param>
+        /// <param name="max">The finishing number.</param>
+        /// <param name="exclusionFilter">A function returning true for any number to be excluded.</param>
+        /// <returns>An enumerable collection of integers starting at <paramref name="min"/> and ending at <paramref name="max"/>, with any exclusions specified.</returns>
+        internal static IEnumerable<int> GetRange(int min, int max, Func<int, bool> exclusionFilter)
+        {
+            var range = Enumerable.Range(min, (max - min + 1));
+            if (exclusionFilter != null)
+            {
+                range = range.Where(i => !exclusionFilter(i));
+            }
+
+            return range;
+        }
+
+        /// <summary>
+        /// Generates a range of numbers with no exclusions.
+        /// </summary>
+        /// <param name="min">The starting number.</param>
+        /// <param name="max">The finishing number.</param>
+        /// <returns>An enumerable collection of integers starting at <paramref name="min"/> and ending at <paramref name="max"/>.</returns>
+        internal static IEnumerable<int> GetRange(int min, int max)
+        {
+            return GetRange(min, max, null);
+        }
+    }
+}

--- a/source/Core/Internal/AntiXssLibrary/CodeCharts/Lower.cs
+++ b/source/Core/Internal/AntiXssLibrary/CodeCharts/Lower.cs
@@ -1,0 +1,561 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Lower.cs" company="Microsoft Corporation">
+//   Copyright (c) 2008, 2009, 2010 All Rights Reserved, Microsoft Corporation
+//
+//   This source is subject to the Microsoft Permissive License.
+//   Please see the License.txt file for more information.
+//   All other rights reserved.
+//
+//   THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+//   KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//   IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//   PARTICULAR PURPOSE.
+//
+// </copyright>
+// <summary>
+//   Provides safe character positions for the lower section of the UTF code tables.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Security.Application.CodeCharts
+{
+    using System.Collections;
+
+    /// <summary>
+    /// Provides safe character positions for the lower section of the UTF code tables.
+    /// </summary>
+    internal static class Lower
+    {
+        /// <summary>
+        /// Determines if the specified flag is set.
+        /// </summary>
+        /// <param name="flags">The value to check.</param>
+        /// <param name="flagToCheck">The flag to check for.</param>
+        /// <returns>true if the flag is set, otherwise false.</returns>
+        public static bool IsFlagSet(LowerCodeCharts flags, LowerCodeCharts flagToCheck)
+        {
+            return (flags & flagToCheck) != 0;
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Basic Latin code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable BasicLatin()
+        {
+            return CodeChartHelper.GetRange(0x0020, 0x007E);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Latin 1 Supplement code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Latin1Supplement()
+        {
+            return CodeChartHelper.GetRange(0x00A1, 0x00FF, i => (i == 0x00AD));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Latin Extended A code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable LatinExtendedA()
+        {
+            return CodeChartHelper.GetRange(0x0100, 0x17F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Latin Extended B code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable LatinExtendedB()
+        {
+            return CodeChartHelper.GetRange(0x0180, 0x024F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the IPA Extensions code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable IpaExtensions()
+        {
+            return CodeChartHelper.GetRange(0x0250, 0x2AF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Spacing Modifiers code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable SpacingModifierLetters()
+        {
+            return CodeChartHelper.GetRange(0x02B0, 0x2FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Combining Diacritical Marks code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CombiningDiacriticalMarks()
+        {
+            return CodeChartHelper.GetRange(0x0300, 0x36F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Greek and Coptic code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable GreekAndCoptic()
+        {
+            return CodeChartHelper.GetRange(
+                0x0370, 
+                0x03FF, 
+                i => (i == 0x378 || i == 0x379 || (i >= 0x37F && i <= 0x383) || i == 0x38B || i == 0x38D || i == 0x3A2));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Cyrillic code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Cyrillic()
+        {
+            return CodeChartHelper.GetRange(0x0400, 0x04FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Cyrillic Supplement code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CyrillicSupplement()
+        {
+            return CodeChartHelper.GetRange(0x0500, 0x0525);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Armenian code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>        
+        public static IEnumerable Armenian()
+        {
+            return CodeChartHelper.GetRange(
+                0x0531, 
+                0x058A,
+                i => (i == 0x0557 || i == 0x0558 || i == 0x0560 || i == 0x0588));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Hebrew code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Hebrew()
+        {
+            return CodeChartHelper.GetRange(
+                0x0591, 
+                0x05F4,
+                i => ((i >= 0x05C8 && i <= 0x05CF) || (i >= 0x05EB && i <= 0x05EF)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Arabic code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Arabic()
+        {
+            return CodeChartHelper.GetRange(
+                0x0600, 
+                0x06FF,
+                i => (i == 0x0604 ||
+                    i == 0x0605 ||
+                    i == 0x061C ||
+                    i == 0x061d ||
+                    i == 0x0620 ||
+                    i == 0x065F));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Syriac code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Syriac()
+        {
+            return CodeChartHelper.GetRange(0x0700, 0x074F, i => (i == 0x070E || i == 0x074B || i == 0x074C));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Arabic Supplement code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable ArabicSupplement()
+        {
+            return CodeChartHelper.GetRange(0x0750, 0x077F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Thaana code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Thaana()
+        {
+            return CodeChartHelper.GetRange(0x0780, 0x07B1);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Nko code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Nko()
+        {
+            return CodeChartHelper.GetRange(0x07C0, 0x07FA);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Samaritan code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Samaritan()
+        {
+            return CodeChartHelper.GetRange(0x0800, 0x083E, i => (i == 0x082E || i == 0x082F));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Devenagari code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Devanagari()
+        {
+            return CodeChartHelper.GetRange(
+                0x0900, 
+                0x097F,
+                i => (i == 0x093A ||
+                    i == 0x093B ||
+                    i == 0x094F ||
+                    i == 0x0956 ||
+                    i == 0x0957 ||
+                    (i >= 0x0973 && i <= 0x0978)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Bengali code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Bengali()
+        {
+            return CodeChartHelper.GetRange(
+                0x0981, 
+                0x09FB,
+                i => (i == 0x0984 ||
+                    i == 0x098D ||
+                    i == 0x098E ||
+                    i == 0x0991 ||
+                    i == 0x0992 ||
+                    i == 0x09A9 ||
+                    i == 0x09B1 ||
+                    i == 0x09B3 ||
+                    i == 0x09B4 ||
+                    i == 0x09B5 ||
+                    i == 0x09BA ||
+                    i == 0x09BB ||
+                    i == 0x09C5 ||
+                    i == 0x09C6 ||
+                    i == 0x09C9 ||
+                    i == 0x09CA ||
+                    (i >= 0x09CF && i <= 0x09D6) ||
+                    (i >= 0x09D8 && i <= 0x09DB) ||
+                    i == 0x09DE ||
+                    i == 0x09E4 ||
+                    i == 0x09E5));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Gurmukhi code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Gurmukhi()
+        {
+            return CodeChartHelper.GetRange(
+                0x0A01, 
+                0x0A75,
+                i => (i == 0x0A04 ||
+                    (i >= 0x0A0B && i <= 0x0A0E) ||
+                    i == 0x0A11 ||
+                    i == 0x0A12 ||
+                    i == 0x0A29 ||
+                    i == 0x0A31 ||
+                    i == 0x0A34 ||
+                    i == 0x0A37 ||
+                    i == 0x0A3A ||
+                    i == 0x0A3B ||
+                    i == 0x0A3D ||
+                    (i >= 0x0A43 && i <= 0x0A46) ||
+                    i == 0x0A49 ||
+                    i == 0x0A4A ||
+                    (i >= 0x0A4E && i <= 0x0A50) ||
+                    (i >= 0x0A52 && i <= 0x0A58) ||
+                    i == 0x0A5D ||
+                    (i >= 0x0A5F && i <= 0x0A65)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Gujarati code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Gujarati()
+        {
+            return CodeChartHelper.GetRange(
+                0x0A81, 
+                0x0AF1,
+                i => (i == 0x0A84 ||
+                    i == 0x0A8E ||
+                    i == 0x0A92 ||
+                    i == 0x0AA9 ||
+                    i == 0x0AB1 ||
+                    i == 0x0AB4 ||
+                    i == 0x0ABA ||
+                    i == 0x0ABB ||
+                    i == 0x0AC6 ||
+                    i == 0x0ACA ||
+                    i == 0x0ACE ||
+                    i == 0x0ACF ||
+                    (i >= 0xAD1 && i <= 0x0ADF) ||
+                    i == 0x0AE4 ||
+                    i == 0x0AE5 ||
+                    i == 0x0AF0));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Oriya code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Oriya()
+        {
+            return CodeChartHelper.GetRange(
+                0x0B01, 
+                0x0B71,
+                i => (i == 0x0B04 ||
+                    i == 0x0B0D ||
+                    i == 0x0B0E ||
+                    i == 0x0B11 ||
+                    i == 0x0B12 ||
+                    i == 0x0B29 ||
+                    i == 0x0B31 ||
+                    i == 0x0B34 ||
+                    i == 0x0B3A ||
+                    i == 0x0B3B ||
+                    i == 0x0B45 ||
+                    i == 0x0B46 ||
+                    i == 0x0B49 ||
+                    i == 0x0B4A ||
+                    (i >= 0x0B4E && i <= 0x0B55) ||
+                    (i >= 0x0B58 && i <= 0x0B5B) ||
+                    i == 0x0B5E ||
+                    i == 0x0B64 ||
+                    i == 0x0B65));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Tamil code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "Lots of range exclusions, cannot be simplified.")]
+        public static IEnumerable Tamil()
+        {
+            return CodeChartHelper.GetRange(
+                0x0B82, 
+                0x0BFA,
+                i => (i == 0x0B84 ||
+                    i == 0x0B8B ||
+                    i == 0x0B8C ||
+                    i == 0x0B8D ||
+                    i == 0x0B91 ||
+                    i == 0x0B96 ||
+                    i == 0x0B97 ||
+                    i == 0x0B98 ||
+                    i == 0x0B9B ||
+                    i == 0x0B9D ||
+                    i == 0x0BA0 ||
+                    i == 0x0BA1 ||
+                    i == 0x0BA2 ||
+                    i == 0x0BA5 ||
+                    i == 0x0BA6 ||
+                    i == 0x0BA7 ||
+                    i == 0x0BAB ||
+                    i == 0x0BAC ||
+                    i == 0x0BAD ||
+                    (i >= 0x0BBA && i <= 0x0BBD) ||
+                    i == 0x0BC3 ||
+                    i == 0x0BC4 ||
+                    i == 0x0BC5 ||
+                    i == 0x0BC9 ||
+                    i == 0x0BCE ||
+                    i == 0x0BCF ||
+                    (i >= 0x0BD1 && i <= 0x0BD6) ||
+                    (i >= 0x0BD8 && i <= 0x0BE5)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Telugu code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Telugu()
+        {
+            return CodeChartHelper.GetRange(
+                0x0C01, 
+                0x0C7F,
+                i => (i == 0x0C04 ||
+                    i == 0x0C0D ||
+                    i == 0x0C11 ||
+                    i == 0x0C29 ||
+                    i == 0x0C34 ||
+                    i == 0x0C3A ||
+                    i == 0x0C3B ||
+                    i == 0x0C3C ||
+                    i == 0x0C45 ||
+                    i == 0x0C49 ||
+                    (i >= 0x0C4E && i <= 0x0C54) ||
+                    i == 0x0C57 ||
+                    (i >= 0x0C5A && i <= 0x0C5F) ||
+                    i == 0x0C64 ||
+                    i == 0x0C65 ||
+                    (i >= 0x0C70 && i <= 0x0C77)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Kannada code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>        
+        public static IEnumerable Kannada()
+        {
+            return CodeChartHelper.GetRange(
+                0x0C82, 
+                0x0CF2,
+                i => (i == 0x0C84 ||
+                    i == 0x0C8D ||
+                    i == 0x0C91 ||
+                    i == 0x0CA9 ||
+                    i == 0x0CB4 ||
+                    i == 0x0CBA ||
+                    i == 0x0CBB ||
+                    i == 0x0CC5 ||
+                    i == 0x0CC9 ||
+                    (i >= 0x0CCE && i <= 0x0CD4) ||
+                    (i >= 0x0CD7 && i <= 0x0CDD) ||
+                    i == 0x0CDF ||
+                    i == 0x0CE4 ||
+                    i == 0x0CE5 ||
+                    i == 0x0CF0));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Malayalam code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Malayalam()
+        {
+            return CodeChartHelper.GetRange(
+                0x0D02, 
+                0x0D7F,
+                i => (i == 0x0D04 ||
+                    i == 0x0D0D ||
+                    i == 0x0D11 ||
+                    i == 0x0D29 ||
+                    i == 0x0D3A ||
+                    i == 0x0D3B ||
+                    i == 0x0D3C ||
+                    i == 0x0D45 ||
+                    i == 0x0D49 ||
+                    (i >= 0x0D4E && i <= 0x0D56) ||
+                    (i >= 0x0D58 && i <= 0x0D5F) ||
+                    i == 0x0D64 ||
+                    i == 0x0D65 ||
+                    i == 0x0D76 ||
+                    i == 0x0D77 ||
+                    i == 0x0D78));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Sinhala code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Sinhala()
+        {
+            return CodeChartHelper.GetRange(
+                0x0D82, 
+                0x0DF4,
+                i => (i == 0x0D84 ||
+                    i == 0x0D97 ||
+                    i == 0X0D98 ||
+                    i == 0x0D99 ||
+                    i == 0x0DB2 ||
+                    i == 0x0DBC ||
+                    i == 0x0DBE ||
+                    i == 0x0DBF ||
+                    i == 0x0DC7 ||
+                    i == 0x0DC8 ||
+                    i == 0x0DC9 ||
+                    (i >= 0x0DCB && i <= 0x0DCE) ||
+                    i == 0x0DD5 ||
+                    i == 0x0DD7 ||
+                    (i >= 0x0DE0 && i <= 0x0DF1)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Thai code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Thai()
+        {
+            return CodeChartHelper.GetRange(0x0E01, 0x0E5B, i => (i >= 0x0E3B && i <= 0x0E3E));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Lao code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "Lots of range exclusions, cannot be simplified.")]
+        public static IEnumerable Lao()
+        {
+            return CodeChartHelper.GetRange(
+                0x0E81, 
+                0x0EDD,
+                i => (i == 0x0E83 ||
+                    i == 0x0E85 ||
+                    i == 0x0E86 ||
+                    i == 0x0E89 ||
+                    i == 0x0E8B ||
+                    i == 0x0E8C ||
+                    (i >= 0x0E8E && i <= 0x0E93) ||
+                    i == 0x0E98 ||
+                    i == 0x0EA0 ||
+                    i == 0x0EA4 ||
+                    i == 0x0EA6 ||
+                    i == 0x0EA8 ||
+                    i == 0x0EA9 ||
+                    i == 0x0EAC ||
+                    i == 0x0EBA ||
+                    i == 0x0EBE ||
+                    i == 0x0EBF ||
+                    i == 0x0EC5 ||
+                    i == 0x0EC7 ||
+                    i == 0x0ECE ||
+                    i == 0x0ECF ||
+                    i == 0x0EDA ||
+                    i == 0x0EDB));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Tibetan code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Tibetan()
+        {
+            return CodeChartHelper.GetRange(
+                0x0F00, 
+                0x0FD8,
+                i => (i == 0x0F48 ||
+                      (i >= 0x0F6D && i <= 0x0F70) ||
+                      (i >= 0x0F8C && i <= 0x0F8F) ||
+                      i == 0x0F98 ||
+                      i == 0x0FBD ||
+                      i == 0x0FCD));
+        }
+    }
+}

--- a/source/Core/Internal/AntiXssLibrary/CodeCharts/LowerMiddle.cs
+++ b/source/Core/Internal/AntiXssLibrary/CodeCharts/LowerMiddle.cs
@@ -1,0 +1,377 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="LowerMiddle.cs" company="Microsoft Corporation">
+//   Copyright (c) 2008, 2009, 2010 All Rights Reserved, Microsoft Corporation
+//
+//   This source is subject to the Microsoft Permissive License.
+//   Please see the License.txt file for more information.
+//   All other rights reserved.
+//
+//   THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+//   KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//   IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//   PARTICULAR PURPOSE.
+//
+// </copyright>
+// <summary>
+//   Provides safe character positions for the lower middle section of the UTF code tables.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+// ReSharper disable CheckNamespace
+namespace Microsoft.Security.Application.CodeCharts
+    // ReSharper restore CheckNamespace
+{
+    using System.Collections;
+
+    /// <summary>
+    /// Provides safe character positions for the lower middle section of the UTF code tables.
+    /// </summary>
+    internal static class LowerMiddle
+    {
+        /// <summary>
+        /// Determines if the specified flag is set.
+        /// </summary>
+        /// <param name="flags">The value to check.</param>
+        /// <param name="flagToCheck">The flag to check for.</param>
+        /// <returns>true if the flag is set, otherwise false.</returns>
+        public static bool IsFlagSet(LowerMidCodeCharts flags, LowerMidCodeCharts flagToCheck)
+        {
+            return (flags & flagToCheck) != 0;
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Myanmar code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Myanmar()
+        {
+            return CodeChartHelper.GetRange(0x1000, 0x109F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Georgian code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>        
+        public static IEnumerable Georgian()
+        {
+            return CodeChartHelper.GetRange(0x10A0, 0x10FC, i => (i >= 0x10C6 && i <= 0x10CF));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Hangul Jamo code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>   
+        public static IEnumerable HangulJamo()
+        {
+            return CodeChartHelper.GetRange(0x1100, 0x11FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Ethiopic code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>   
+        public static IEnumerable Ethiopic()
+        {
+            return CodeChartHelper.GetRange(
+                0x1200, 
+                0x137C,
+                i => (i == 0x1249 ||
+                    i == 0x124E ||
+                    i == 0x124F ||
+                    i == 0x1257 ||
+                    i == 0x1259 ||
+                    i == 0x125E ||
+                    i == 0x125F ||
+                    i == 0x1289 ||
+                    i == 0x128E ||
+                    i == 0x128F ||
+                    i == 0x12B1 ||
+                    i == 0x12B6 ||
+                    i == 0x12B7 ||
+                    i == 0x12BF ||
+                    i == 0x12C1 ||
+                    i == 0x12C6 ||
+                    i == 0x12C7 ||
+                    i == 0x12D7 ||
+                    i == 0x1311 ||
+                    i == 0x1316 ||
+                    i == 0x1317 ||
+                    (i >= 0x135B && i <= 0x135E)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Ethiopic Supplement code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>   
+        public static IEnumerable EthiopicSupplement()
+        {
+            return CodeChartHelper.GetRange(0x1380, 0x1399);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Cherokee code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>   
+        public static IEnumerable Cherokee()
+        {
+            return CodeChartHelper.GetRange(0x13A0, 0x13F4);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Unified Canadian Aboriginal Syllabic code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>  
+        public static IEnumerable UnifiedCanadianAboriginalSyllabics()
+        {
+            return CodeChartHelper.GetRange(0x1400, 0x167F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Ogham code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns> 
+        public static IEnumerable Ogham()
+        {
+            return CodeChartHelper.GetRange(0x1680, 0x169C);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Runic code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns> 
+        public static IEnumerable Runic()
+        {
+            return CodeChartHelper.GetRange(0x16A0, 0x16F0);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Tagalog code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns> 
+        public static IEnumerable Tagalog()
+        {
+            return CodeChartHelper.GetRange(0x1700, 0x1714, i => (i == 0x170D));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Hanunoo code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns> 
+        public static IEnumerable Hanunoo()
+        {
+            return CodeChartHelper.GetRange(0x1720, 0x1736);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Buhid code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns> 
+        public static IEnumerable Buhid()
+        {
+            return CodeChartHelper.GetRange(0x1740, 0x1753);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Tagbanwa code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns> 
+        public static IEnumerable Tagbanwa()
+        {
+            return CodeChartHelper.GetRange(0x1760, 0x1773, i => (i == 0x176D || i == 0x1771));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Khmer code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns> 
+        public static IEnumerable Khmer()
+        {
+            return CodeChartHelper.GetRange(
+                0x1780, 
+                0x17F9,
+                i => (i == 0x17DE ||
+                      i == 0x17DF ||
+                      (i >= 0x17EA && i <= 0x17EF)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Mongolian code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns> 
+        public static IEnumerable Mongolian()
+        {
+            return CodeChartHelper.GetRange(
+                0x1800, 
+                0x18AA,
+                i => (i == 0x180F ||
+                      (i >= 0x181A && i <= 0x181F) ||
+                      (i >= 0x1878 && i <= 0x187F)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Unified Canadian Aboriginal Syllabic Extended code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>  
+        public static IEnumerable UnifiedCanadianAboriginalSyllabicsExtended()
+        {
+            return CodeChartHelper.GetRange(0x18B0, 0x18F5);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Limbu code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>  
+        public static IEnumerable Limbu()
+        {
+            return CodeChartHelper.GetRange(
+                0x1900, 
+                0x194F,
+                i => (i == 0x191D ||
+                    i == 0x191E ||
+                    i == 0x191F ||
+                    (i >= 0x192C && i <= 0x192F) ||
+                    (i >= 0x193C && i <= 0x193F) ||
+                    i == 0x1941 ||
+                    i == 0x1942 ||
+                    i == 0x1943));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Tai Le code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>  
+        public static IEnumerable TaiLe()
+        {
+            return CodeChartHelper.GetRange(0x1950, 0x1974, i => (i == 0x196E || i == 0x196F));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the New Tai Lue code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>          
+        public static IEnumerable NewTaiLue()
+        {
+            return CodeChartHelper.GetRange(
+                0x1980, 
+                0x19DF,
+                i => ((i >= 0x19AC && i <= 0x19AF) ||
+                      (i >= 0x19CA && i <= 0x19CF) ||
+                      (i >= 0x19DB && i <= 0x19DD)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Khmer Symbols code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>   
+        public static IEnumerable KhmerSymbols()
+        {
+            return CodeChartHelper.GetRange(0x19E0, 0x19FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Khmer Symbols code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>   
+        public static IEnumerable Buginese()
+        {
+            return CodeChartHelper.GetRange(0x1A00, 0x1A1F, i => (i == 0x1A1C || i == 0x1A1D));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Tai Tham code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>   
+        public static IEnumerable TaiTham()
+        {
+            return CodeChartHelper.GetRange(
+                0x1A20, 
+                0x1AAD,
+                i => (i == 0x1A5F ||
+                    i == 0x1A7D ||
+                    i == 0x1A7E ||
+                    (i >= 0x1A8A && i <= 0x1A8F) ||
+                    (i >= 0x1A9A && i <= 0x1A9F)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Balinese code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>   
+        public static IEnumerable Balinese()
+        {
+            return CodeChartHelper.GetRange(0x1B00, 0x1B7C, i => (i >= 0x1B4C && i <= 0x1B4F));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Sudanese code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>   
+        public static IEnumerable Sudanese()
+        {
+            return CodeChartHelper.GetRange(0x1B80, 0x1BB9, i => (i >= 0x1BAB && i <= 0x1BAD));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Lepcha code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>   
+        public static IEnumerable Lepcha()
+        {
+            return CodeChartHelper.GetRange(0x1C00, 0x1C4F, i => ((i >= 0x1C38 && i <= 0x1C3A) || (i >= 0x1C4A && i <= 0x1C4C)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Ol Chiki code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>  
+        public static IEnumerable OlChiki()
+        {
+            return CodeChartHelper.GetRange(0x1C50, 0x1C7F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Vedic Extensions code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>  
+        public static IEnumerable VedicExtensions()
+        {
+            return CodeChartHelper.GetRange(0x1CD0, 0x1CF2);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Phonetic Extensions code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>  
+        public static IEnumerable PhoneticExtensions()
+        {
+            return CodeChartHelper.GetRange(0x1D00, 0x1D7F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Phonetic Extensions Supplement code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>  
+        public static IEnumerable PhoneticExtensionsSupplement()
+        {
+            return CodeChartHelper.GetRange(0x1D80, 0x1DBF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Combining Diacritical Marks Supplement code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>  
+        public static IEnumerable CombiningDiacriticalMarksSupplement()
+        {
+            return CodeChartHelper.GetRange(0x1DC0, 0x1DFF, i => (i >= 0x1DE7 && i <= 0x1DFC));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Latin Extended Addition code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>  
+        public static IEnumerable LatinExtendedAdditional()
+        {
+            return CodeChartHelper.GetRange(0x1E00, 0x1EFF);
+        }
+    }
+}

--- a/source/Core/Internal/AntiXssLibrary/CodeCharts/Middle.cs
+++ b/source/Core/Internal/AntiXssLibrary/CodeCharts/Middle.cs
@@ -1,0 +1,373 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Middle.cs" company="Microsoft Corporation">
+//   Copyright (c) 2008, 2009, 2010 All Rights Reserved, Microsoft Corporation
+//
+//   This source is subject to the Microsoft Permissive License.
+//   Please see the License.txt file for more information.
+//   All other rights reserved.
+//
+//   THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+//   KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//   IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//   PARTICULAR PURPOSE.
+//
+// </copyright>
+// <summary>
+//   Provides safe character positions for the lower middle section of the UTF code tables.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+// ReSharper disable CheckNamespace
+namespace Microsoft.Security.Application.CodeCharts
+    // ReSharper restore CheckNamespace
+{
+    using System.Collections;
+
+    /// <summary>
+    /// Provides safe character positions for the middle section of the UTF code tables.
+    /// </summary>
+    internal static class Middle
+    {
+        /// <summary>
+        /// Determines if the specified flag is set.
+        /// </summary>
+        /// <param name="flags">The value to check.</param>
+        /// <param name="flagToCheck">The flag to check for.</param>
+        /// <returns>true if the flag is set, otherwise false.</returns>
+        public static bool IsFlagSet(MidCodeCharts flags, MidCodeCharts flagToCheck)
+        {
+            return (flags & flagToCheck) != 0;
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Greek Extended code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable GreekExtended()
+        {
+            return CodeChartHelper.GetRange(
+                0x1F00, 
+                0x1FFE,
+                i => (i == 0x1F16 ||
+                    i == 0x1F17 ||
+                    i == 0x1F1E ||
+                    i == 0x1F1F ||
+                    i == 0x1F46 ||
+                    i == 0x1F47 ||
+                    i == 0x1F4E ||
+                    i == 0x1F4F ||
+                    i == 0x1F58 ||
+                    i == 0x1F5A ||
+                    i == 0x1F5C ||
+                    i == 0x1F5E ||
+                    i == 0x1F7E ||
+                    i == 0x1F7F ||
+                    i == 0x1FB5 ||
+                    i == 0x1FC5 ||
+                    i == 0x1FD4 ||
+                    i == 0x1FD5 ||
+                    i == 0x1FDC ||
+                    i == 0x1FF0 ||
+                    i == 0x1FF1 ||
+                    i == 0x1FF5));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the General Punctuation code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable GeneralPunctuation()
+        {
+            return CodeChartHelper.GetRange(0x2000, 0x206F, i => (i >= 0x2065 && i <= 0x2069));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Superscripts and subscripts code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable SuperscriptsAndSubscripts()
+        {
+            return CodeChartHelper.GetRange(0x2070, 0x2094, i => (i == 0x2072 || i == 0x2073 || i == 0x208F));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Currency Symbols code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CurrencySymbols()
+        {
+            return CodeChartHelper.GetRange(0x20A0, 0x20B8);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Combining Diacritrical Marks for Symbols code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CombiningDiacriticalMarksForSymbols()
+        {
+            return CodeChartHelper.GetRange(0x20D0, 0x20F0);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Letterlike Symbols code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable LetterlikeSymbols()
+        {
+            return CodeChartHelper.GetRange(0x2100, 0x214F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Number Forms code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable NumberForms()
+        {
+            return CodeChartHelper.GetRange(0x2150, 0x2189);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Arrows code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Arrows()
+        {
+            return CodeChartHelper.GetRange(0x2190, 0x21FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Mathematical Operators code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable MathematicalOperators()
+        {
+            return CodeChartHelper.GetRange(0x2200, 0x22FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Miscellaneous Technical code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable MiscellaneousTechnical()
+        {
+            return CodeChartHelper.GetRange(0x2300, 0x23E8);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Control Pictures code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable ControlPictures()
+        {
+            return CodeChartHelper.GetRange(0x2400, 0x2426);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the OCR code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable OpticalCharacterRecognition()
+        {
+            return CodeChartHelper.GetRange(0x2440, 0x244A);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Enclosed Alphanumerics code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable EnclosedAlphanumerics()
+        {
+            return CodeChartHelper.GetRange(0x2460, 0x24FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Box Drawing code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable BoxDrawing()
+        {
+            return CodeChartHelper.GetRange(0x2500, 0x257F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Block Elements code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable BlockElements()
+        {
+            return CodeChartHelper.GetRange(0x2580, 0x259F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Geometric Shapes code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable GeometricShapes()
+        {
+            return CodeChartHelper.GetRange(0x25A0, 0x25FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Miscellaneous Symbols code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable MiscellaneousSymbols()
+        {
+            return CodeChartHelper.GetRange(0x2600, 0x26FF, i => (i == 0x26CE || i == 0x26E2 || (i >= 0x26E4 && i <= 0x26E7)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Dingbats code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Dingbats()
+        {
+            return CodeChartHelper.GetRange(
+                0x2701, 
+                0x27BE,
+                i => (i == 0x2705 ||
+                    i == 0x270A ||
+                    i == 0x270B ||
+                    i == 0x2728 ||
+                    i == 0x274C ||
+                    i == 0x274E ||
+                    i == 0x2753 ||
+                    i == 0x2754 ||
+                    i == 0x2755 ||
+                    i == 0x275F ||
+                    i == 0x2760 ||
+                    i == 0x2795 ||
+                    i == 0x2796 ||
+                    i == 0x2797 ||
+                    i == 0x27B0));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Miscellaneous Mathematical Symbols A code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable MiscellaneousMathematicalSymbolsA()
+        {
+            return CodeChartHelper.GetRange(0x27C0, 0x27EF, i => (i == 0x27CB || i == 0x27CD || i == 0x27CE || i == 0x27CF));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Supplemental Arrows A code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable SupplementalArrowsA()
+        {
+            return CodeChartHelper.GetRange(0x27F0, 0x27FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Braille Patterns code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable BraillePatterns()
+        {
+            return CodeChartHelper.GetRange(0x2800, 0x28FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Supplemental Arrows B code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable SupplementalArrowsB()
+        {
+            return CodeChartHelper.GetRange(0x2900, 0x297F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Miscellaneous Mathematical Symbols B code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable MiscellaneousMathematicalSymbolsB()
+        {
+            return CodeChartHelper.GetRange(0x2980, 0x29FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Supplemental Mathematical Operators code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable SupplementalMathematicalOperators()
+        {
+            return CodeChartHelper.GetRange(0x2A00, 0x2AFF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Miscellaneous Symbols and Arrows code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable MiscellaneousSymbolsAndArrows()
+        {
+            return CodeChartHelper.GetRange(0x2B00, 0x2B59, i => (i == 0x2B4D || i == 0x2B4E || i == 0x2B4F));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Glagolitic code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Glagolitic()
+        {
+            return CodeChartHelper.GetRange(0x2C00, 0x2C5E, i => (i == 0x2C2F));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Latin Extended C code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable LatinExtendedC()
+        {
+            return CodeChartHelper.GetRange(0x2C60, 0x2C7F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Coptic table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Coptic()
+        {
+            return CodeChartHelper.GetRange(0x2C80, 0x2CFF, i => (i >= 0x2CF2 && i <= 0x2CF8));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Georgian Supplement code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable GeorgianSupplement()
+        {
+            return CodeChartHelper.GetRange(0x2D00, 0x2D25);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Tifinagh code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Tifinagh()
+        {
+            return CodeChartHelper.GetRange(0x2D30, 0x2D6F, i => (i >= 0x2D66 && i <= 0x2D6E));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Ethiopic Extended code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable EthiopicExtended()
+        {
+            return CodeChartHelper.GetRange(                
+                0x2D80, 
+                0x2DDE,
+                i => ((i >= 0x2D97 && i <= 0x2D9F) ||
+                    i == 0x2DA7 ||
+                    i == 0x2DAF ||
+                    i == 0x2DB7 ||
+                    i == 0x2DBF ||
+                    i == 0x2DC7 ||
+                    i == 0x2DCF ||
+                    i == 0x2DD7 ||
+                    i == 0x2DDF));
+        }
+    }
+}

--- a/source/Core/Internal/AntiXssLibrary/CodeCharts/Upper.cs
+++ b/source/Core/Internal/AntiXssLibrary/CodeCharts/Upper.cs
@@ -1,0 +1,279 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Upper.cs" company="Microsoft Corporation">
+//   Copyright (c) 2008, 2009, 2010 All Rights Reserved, Microsoft Corporation
+//
+//   This source is subject to the Microsoft Permissive License.
+//   Please see the License.txt file for more information.
+//   All other rights reserved.
+//
+//   THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+//   KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//   IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//   PARTICULAR PURPOSE.
+//
+// </copyright>
+// <summary>
+//   Provides safe character positions for the upper section of the UTF code tables.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+// ReSharper disable CheckNamespace
+namespace Microsoft.Security.Application.CodeCharts
+    // ReSharper restore CheckNamespace
+{
+    using System.Collections;
+    using System.Linq;
+
+    /// <summary>
+    /// Provides safe character positions for the upper section of the UTF code tables.
+    /// </summary>
+    internal static class Upper
+    {
+        /// <summary>
+        /// Determines if the specified flag is set.
+        /// </summary>
+        /// <param name="flags">The value to check.</param>
+        /// <param name="flagToCheck">The flag to check for.</param>
+        /// <returns>true if the flag is set, otherwise false.</returns>
+        public static bool IsFlagSet(UpperCodeCharts flags, UpperCodeCharts flagToCheck)
+        {
+            return (flags & flagToCheck) != 0;
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Devanagari Extended code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable DevanagariExtended()
+        {
+            return CodeChartHelper.GetRange(0xA8E0, 0xA8FB);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Kayah Li code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable KayahLi()
+        {
+            return CodeChartHelper.GetRange(0xA900, 0xA92F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Rejang code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Rejang()
+        {
+            return CodeChartHelper.GetRange(0xA930, 0xA953).Concat(new[] { 0xA95F });
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Hangul Jamo Extended A code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable HangulJamoExtendedA()
+        {
+            return CodeChartHelper.GetRange(0xA960, 0xA97C);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Javanese code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Javanese()
+        {
+            return CodeChartHelper.GetRange(0xA980, 0xA9DF, i => (i == 0xA9CE || (i >= 0xA9DA && i <= 0xA9DD)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Cham code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Cham()
+        {
+            return CodeChartHelper.GetRange(
+                0xAA00, 
+                0xAA5F,
+                i => ((i >= 0xAA37 && i <= 0xAA3F) ||
+                    i == 0xAA4E ||
+                    i == 0xAA4F ||
+                    i == 0xAA5A ||
+                    i == 0xAA5B));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Myanmar Extended A code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable MyanmarExtendedA()
+        {
+            return CodeChartHelper.GetRange(0xAA60, 0xAA7B);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Myanmar Extended A code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable TaiViet()
+        {
+            return CodeChartHelper.GetRange(0xAA80, 0xAAC2).Concat(CodeChartHelper.GetRange(0xAADB, 0xAADF));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Meetei Mayek code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable MeeteiMayek()
+        {
+            return CodeChartHelper.GetRange(0xABC0, 0xABF9, i => (i == 0xABEE || i == 0xABEF));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Hangul Syllables code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable HangulSyllables()
+        {
+            return CodeChartHelper.GetRange(0xAC00, 0xD7A3);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Hangul Jamo Extended B code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable HangulJamoExtendedB()
+        {
+            return CodeChartHelper.GetRange(0xD7B0, 0xD7FB, i => (i == 0xD7C7 || i == 0xD7C8 || i == 0xD7C9 || i == 0xD7CA));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the CJK Compatibility Ideographs code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CjkCompatibilityIdeographs()
+        {
+            return CodeChartHelper.GetRange(0xF900, 0xFAD9, i => (i == 0xFA2E || i == 0xFA2F || i == 0xFA6E || i == 0xFA6F));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Alphabetic Presentation Forms code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable AlphabeticPresentationForms()
+        {
+            return CodeChartHelper.GetRange(
+                0xFB00, 
+                0xFB4F,
+                i => ((i >= 0xFB07 && i <= 0xFB12) ||
+                    (i >= 0xFB18 && i <= 0xFB1C) ||
+                    i == 0xFB37 ||
+                    i == 0xFB3D ||
+                    i == 0xFB3F ||
+                    i == 0xFB42 ||
+                    i == 0xFB45));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Arabic Presentation Forms A code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable ArabicPresentationFormsA()
+        {
+            return CodeChartHelper.GetRange(
+                0xFB50, 
+                0xFDFD,
+                i => ((i >= 0xFBB2 && i <= 0xFBD2) ||
+                    (i >= 0xFD40 && i <= 0xFD4F) ||
+                    i == 0xFD90 ||
+                    i == 0xFD91 ||
+                    (i >= 0xFDC8 && i <= 0xFDEF)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Variation Selectors code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable VariationSelectors()
+        {
+            return CodeChartHelper.GetRange(0xFE00, 0xFE0F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Vertical Forms code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable VerticalForms()
+        {
+            return CodeChartHelper.GetRange(0xFE10, 0xFE19);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Combining Half Marks code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CombiningHalfMarks()
+        {
+            return CodeChartHelper.GetRange(0xFE20, 0xFE26);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the CJK Compatibility Forms code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CjkCompatibilityForms()
+        {
+            return CodeChartHelper.GetRange(0xFE30, 0xFE4F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Small Form Variants code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable SmallFormVariants()
+        {
+            return CodeChartHelper.GetRange(0xFE50, 0xFE6B, i => (i == 0xFE53 || i == 0xFE67));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Arabic Presentation Forms B code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable ArabicPresentationFormsB()
+        {
+            return CodeChartHelper.GetRange(0xFE70, 0xFEFC, i => (i == 0xFE75));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Half Width and Full Width Forms code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable HalfWidthAndFullWidthForms()
+        {
+            return CodeChartHelper.GetRange(
+                0xFF01, 
+                0xFFEE,
+                i => (i == 0xFFBF ||
+                    i == 0xFFC0 ||
+                    i == 0xFFC1 ||
+                    i == 0xFFC8 ||
+                    i == 0xFFC9 ||
+                    i == 0xFFD0 ||
+                    i == 0xFFD1 ||
+                    i == 0xFFD8 ||
+                    i == 0xFFD9 ||
+                    i == 0xFFDD ||
+                    i == 0xFFDE ||
+                    i == 0xFFDF ||
+                    i == 0xFFE7));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Specials code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Specials()
+        {
+            return CodeChartHelper.GetRange(0xFFF9, 0xFFFD);
+        }
+    }
+}

--- a/source/Core/Internal/AntiXssLibrary/CodeCharts/UpperMiddle.cs
+++ b/source/Core/Internal/AntiXssLibrary/CodeCharts/UpperMiddle.cs
@@ -1,0 +1,326 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="UpperMiddle.cs" company="Microsoft Corporation">
+//   Copyright (c) 2008, 2009, 2010 All Rights Reserved, Microsoft Corporation
+//
+//   This source is subject to the Microsoft Permissive License.
+//   Please see the License.txt file for more information.
+//   All other rights reserved.
+//
+//   THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+//   KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//   IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//   PARTICULAR PURPOSE.
+//
+// </copyright>
+// <summary>
+//   Provides safe character positions for the upper middle section of the UTF code tables.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+// ReSharper disable CheckNamespace
+namespace Microsoft.Security.Application.CodeCharts
+    // ReSharper restore CheckNamespace
+{
+    using System.Collections;
+    using System.Linq;
+
+    /// <summary>
+    /// Provides safe character positions for the upper middle section of the UTF code tables.
+    /// </summary>
+    internal static class UpperMiddle
+    {
+        /// <summary>
+        /// Determines if the specified flag is set.
+        /// </summary>
+        /// <param name="flags">The value to check.</param>
+        /// <param name="flagToCheck">The flag to check for.</param>
+        /// <returns>true if the flag is set, otherwise false.</returns>
+        public static bool IsFlagSet(UpperMidCodeCharts flags, UpperMidCodeCharts flagToCheck)
+        {
+            return (flags & flagToCheck) != 0;
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Cyrillic Extended A code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CyrillicExtendedA()
+        {
+            return CodeChartHelper.GetRange(0x2DE0, 0x2DFF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Cyrillic Extended A code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable SupplementalPunctuation()
+        {
+            return CodeChartHelper.GetRange(0x2E00, 0x2E31);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the CJK Radicals Supplement code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CjkRadicalsSupplement()
+        {
+            return CodeChartHelper.GetRange(0x2E80, 0x2EF3, i => (i == 0x2E9A));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Kangxi Radicals code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable KangxiRadicals()
+        {
+            return CodeChartHelper.GetRange(0x2F00, 0x2FD5);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Ideographic Description Characters code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable IdeographicDescriptionCharacters()
+        {
+            return CodeChartHelper.GetRange(0x2FF0, 0x2FFB);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the CJK Symbols and Punctuation code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CjkSymbolsAndPunctuation()
+        {
+            return CodeChartHelper.GetRange(0x3000, 0x303F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Hiragana code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Hiragana()
+        {
+            return CodeChartHelper.GetRange(0x3041, 0x309F, i => (i == 0x3097 || i == 0x3098));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Hiragana code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Katakana()
+        {
+            return CodeChartHelper.GetRange(0x30A0, 0x30FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Bopomofo code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Bopomofo()
+        {
+            return CodeChartHelper.GetRange(0x3105, 0x312D);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Hangul Compatibility Jamo code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable HangulCompatibilityJamo()
+        {
+            return CodeChartHelper.GetRange(0x3131, 0x318E);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Kanbun code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Kanbun()
+        {
+            return CodeChartHelper.GetRange(0x3190, 0x319F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Bopomofo Extended code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable BopomofoExtended()
+        {
+            return CodeChartHelper.GetRange(0x31A0, 0x31B7);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the CJK Strokes code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CjkStrokes()
+        {
+            return CodeChartHelper.GetRange(0x31C0, 0x31E3);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Katakana Phonetic Extensions code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable KatakanaPhoneticExtensions()
+        {
+            return CodeChartHelper.GetRange(0x31F0, 0x31FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Enclosed CJK Letters and Months code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable EnclosedCjkLettersAndMonths()
+        {
+            return CodeChartHelper.GetRange(0x3200, 0x32FE, i => (i == 0x321F));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the CJK Compatibility code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CjkCompatibility()
+        {
+            return CodeChartHelper.GetRange(0x3300, 0x33FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the CJK Unified Ideographs Extension A code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CjkUnifiedIdeographsExtensionA()
+        {
+            return CodeChartHelper.GetRange(0x3400, 0x4DB5);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Yijing Hexagram Symbols code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable YijingHexagramSymbols()
+        {
+            return CodeChartHelper.GetRange(0x4DC0, 0x4DFF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the CJK Unified Ideographs code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CjkUnifiedIdeographs()
+        {
+            return CodeChartHelper.GetRange(0x4E00, 0x9FCB);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Yi Syllables code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable YiSyllables()
+        {
+            return CodeChartHelper.GetRange(0xA000, 0xA48C);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Yi Radicals code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable YiRadicals()
+        {
+            return CodeChartHelper.GetRange(0xA490, 0xA4C6);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Lisu code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Lisu()
+        {
+            return CodeChartHelper.GetRange(0xA4D0, 0xA4FF);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Vai code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Vai()
+        {
+            return CodeChartHelper.GetRange(0xA500, 0xA62B);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Cyrillic Extended B code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CyrillicExtendedB()
+        {
+            return CodeChartHelper.GetRange(
+                0xA640, 
+                0xA697,
+                i => (i == 0xA660 || i == 0xA661 || (i >= 0xA674 && i <= 0xA67b)));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Bamum code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Bamum()
+        {
+            return CodeChartHelper.GetRange(0xA6A0, 0xA6F7);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Modifier Tone Letters code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable ModifierToneLetters()
+        {
+            return CodeChartHelper.GetRange(0xA700, 0xA71F);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Latin Extended D code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable LatinExtendedD()
+        {
+            return CodeChartHelper.GetRange(0xA720, 0xA78C).Concat(
+                   CodeChartHelper.GetRange(0xA7FB, 0xA7FF));
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Syloti Nagri code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable SylotiNagri()
+        {
+            return CodeChartHelper.GetRange(0xA800, 0xA82B);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Common Indic Number Forms code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable CommonIndicNumberForms()
+        {
+            return CodeChartHelper.GetRange(0xA830, 0xA839);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Phags-pa code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Phagspa()
+        {
+            return CodeChartHelper.GetRange(0xA840, 0xA877);
+        }
+
+        /// <summary>
+        /// Provides the safe characters for the Saurashtra code table.
+        /// </summary>
+        /// <returns>The safe characters for the code table.</returns>
+        public static IEnumerable Saurashtra()
+        {
+            return CodeChartHelper.GetRange(0xA880, 0xA8D9, i => (i >= 0xA8C5 && i <= 0xA8CD));
+        }
+    }
+}

--- a/source/Core/Internal/AntiXssLibrary/Encoder.cs
+++ b/source/Core/Internal/AntiXssLibrary/Encoder.cs
@@ -1,0 +1,121 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Encoder.cs" company="Microsoft Corporation">
+//   Copyright (c) 2008, 2009, 2010 All Rights Reserved, Microsoft Corporation
+//
+//   This source is subject to the Microsoft Permissive License.
+//   Please see the License.txt file for more information.
+//   All other rights reserved.
+//
+//   THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+//   KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//   IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//   PARTICULAR PURPOSE.
+//
+// </copyright>
+// <summary>
+//   Performs encoding of input strings to provide protection against
+//   Cross-Site Scripting (XSS) attacks and LDAP injection attacks in
+//   various contexts.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+// ReSharper disable CheckNamespace
+namespace Microsoft.Security.Application
+    // ReSharper restore CheckNamespace
+{
+    using System;
+    using System.Globalization;
+    using System.Text;
+
+    /// <summary>
+    /// Performs encoding of input strings to provide protection against
+    /// Cross-Site Scripting (XSS) attacks and LDAP injection attacks in 
+    /// various contexts.
+    /// </summary>
+    /// <remarks>
+    /// This encoding library uses the Principle of Inclusions, 
+    /// sometimes referred to as "safe-listing" to provide protection 
+    /// against injection attacks.  With safe-listing protection, 
+    /// algorithms look for valid inputs and automatically treat 
+    /// everything outside that set as a potential attack.  This library 
+    /// can be used as a defense in depth approach with other mitigation 
+    /// techniques. It is suitable for applications with high security 
+    /// requirements.
+    /// </remarks>
+    public static class Encoder
+    {
+        /// <summary>
+        /// Encodes input strings for use in HTML.
+        /// </summary>
+        /// <param name="input">String to be encoded.</param>
+        /// <returns>
+        /// Encoded string for use in HTML.
+        /// </returns>
+        /// <remarks>
+        /// All characters not safe listed are encoded to their Unicode decimal value, using &amp;#DECIMAL; notation.
+        /// The default safe characters include:
+        /// <list type="table">
+        /// <item><term>a-z</term><description>Lower case alphabet</description></item>
+        /// <item><term>A-Z</term><description>Upper case alphabet</description></item>
+        /// <item><term>0-9</term><description>Numbers</description></item>
+        /// <item><term>,</term><description>Comma</description></item>
+        /// <item><term>.</term><description>Period</description></item>
+        /// <item><term>-</term><description>Dash</description></item>
+        /// <item><term>_</term><description>Underscore</description></item>
+        /// <item><term>'</term><description>Apostrophe</description></item>
+        /// <item><term> </term><description>Space</description></item>
+        /// </list>
+        /// The safe list may be adjusted using <see cref="UnicodeCharacterEncoder.MarkAsSafe"/>.
+        /// <newpara/>
+        /// Example inputs and their related encoded outputs:
+        /// <list type="table">
+        /// <item><term>&lt;script&gt;alert('XSS Attack!');&lt;/script&gt;</term><description>&amp;lt;script&amp;gt;alert('XSS Attack!');&amp;lt;/script&amp;gt;</description></item>
+        /// <item><term>user@contoso.com</term><description>user@contoso.com</description></item>
+        /// <item><term>Anti-Cross Site Scripting Library</term><description>Anti-Cross Site Scripting Library</description></item>
+        /// <item><term>"Anti-Cross Site Scripting Library"</term><description>&amp;quote;Anti-Cross Site Scripting Library&amp;quote;</description></item>
+        /// </list>
+        /// </remarks>
+        public static string HtmlEncode(string input)
+        {
+            return HtmlEncode(input, false);
+        }
+
+        /// <summary>
+        /// Encodes input strings for use in HTML.
+        /// </summary>
+        /// <param name="input">String to be encoded.</param>
+        /// <param name="useNamedEntities">Value indicating if the HTML 4.0 named entities should be used.</param>
+        /// <returns>
+        /// Encoded string for use in HTML.
+        /// </returns>
+        /// <remarks>
+        /// All characters not safe listed are encoded to their Unicode decimal value, using &amp;#DECIMAL; notation.
+        /// If you choose to use named entities then if a character is an HTML4.0 named entity the named entity will be used.
+        /// The default safe characters include:
+        /// <list type="table">
+        /// <item><term>a-z</term><description>Lower case alphabet</description></item>
+        /// <item><term>A-Z</term><description>Upper case alphabet</description></item>
+        /// <item><term>0-9</term><description>Numbers</description></item>
+        /// <item><term>,</term><description>Comma</description></item>
+        /// <item><term>.</term><description>Period</description></item>
+        /// <item><term>-</term><description>Dash</description></item>
+        /// <item><term>_</term><description>Underscore</description></item>
+        /// <item><term>'</term><description>Apostrophe</description></item>
+        /// <item><term> </term><description>Space</description></item>
+        /// </list>
+        /// The safe list may be adjusted using <see cref="UnicodeCharacterEncoder.MarkAsSafe"/>.
+        /// <newpara/>
+        /// Example inputs and their related encoded outputs:
+        /// <list type="table">
+        /// <item><term>&lt;script&gt;alert('XSS Attack!');&lt;/script&gt;</term><description>&amp;lt;script&amp;gt;alert('XSS Attack!');&amp;lt;/script&amp;gt;</description></item>
+        /// <item><term>user@contoso.com</term><description>user@contoso.com</description></item>
+        /// <item><term>Anti-Cross Site Scripting Library</term><description>Anti-Cross Site Scripting Library</description></item>
+        /// <item><term>"Anti-Cross Site Scripting Library"</term><description>&amp;quote;Anti-Cross Site Scripting Library&amp;quote;</description></item>
+        /// </list>
+        /// </remarks>
+        public static string HtmlEncode(string input, bool useNamedEntities)
+        {
+            return UnicodeCharacterEncoder.HtmlEncode(input, useNamedEntities);
+        }
+    }
+}

--- a/source/Core/Internal/AntiXssLibrary/EncoderUtil.cs
+++ b/source/Core/Internal/AntiXssLibrary/EncoderUtil.cs
@@ -1,0 +1,65 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="EncoderUtil.cs" company="Microsoft Corporation">
+//   Copyright (c) 2008, 2009, 2010 All Rights Reserved, Microsoft Corporation
+//
+//   This source is subject to the Microsoft Permissive License.
+//   Please see the License.txt file for more information.
+//   All other rights reserved.
+//
+//   THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+//   KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//   IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//   PARTICULAR PURPOSE.
+//
+// </copyright>
+// <summary>
+//   Provides helper methods common to all Anti-XSS encoders.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+// ReSharper disable CheckNamespace
+namespace Microsoft.Security.Application
+    // ReSharper restore CheckNamespace
+{
+    using System;
+    using System.Text;
+
+    /// <summary>
+    /// Provides helper methods common to all Anti-XSS encoders.
+    /// </summary>
+    internal static class EncoderUtil
+    {
+        /// <summary>
+        /// Gets an appropriately-sized StringBuilder for the output of an encoding routine.
+        /// </summary>
+        /// <param name="inputLength">The length (in characters) of the input string.</param>
+        /// <param name="worstCaseOutputCharsPerInputChar">The worst-case ratio of output characters per input character.</param>
+        /// <returns>A StringBuilder appropriately-sized to hold the output string.</returns>
+        internal static StringBuilder GetOutputStringBuilder(int inputLength, int worstCaseOutputCharsPerInputChar)
+        {
+            // We treat 32KB byte size (16k chars) as a soft upper boundary for the length of any StringBuilder
+            // that we allocate. We'll try to avoid going above this boundary if we can avoid it so that we
+            // don't allocate objects on the LOH.
+            const int UpperBound = 16 * 1024;
+
+            int charsToAllocate;
+            if (inputLength >= UpperBound)
+            {
+                // We know that the output will contain at least as many characters as the input, so if the
+                // input length exceeds the soft upper boundary just pre-allocate the entire builder and hope for
+                // a best-case outcome.
+                charsToAllocate = inputLength;
+            }
+            else
+            {
+                // Allocate the worst-case if we can, but don't exceed the soft upper boundary.
+                long worstCaseTotalChars = (long)inputLength * worstCaseOutputCharsPerInputChar; // don't overflow Int32
+                charsToAllocate = (int)Math.Min(UpperBound, worstCaseTotalChars);
+            }
+
+            // Once we have chosen an initial value for the StringBuilder size, the StringBuilder type will
+            // efficiently allocate additionally blocks if necessary.
+            return new StringBuilder(charsToAllocate);
+        }
+    }
+}

--- a/source/Core/Internal/AntiXssLibrary/SafeList.cs
+++ b/source/Core/Internal/AntiXssLibrary/SafeList.cs
@@ -1,0 +1,483 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SafeList.cs" company="Microsoft Corporation">
+//   Copyright (c) 2008, 2009, 2010 All Rights Reserved, Microsoft Corporation
+//
+//   This source is subject to the Microsoft Permissive License.
+//   Please see the License.txt file for more information.
+//   All other rights reserved.
+//
+//   THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+//   KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//   IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//   PARTICULAR PURPOSE.
+//
+// </copyright>
+// <summary>
+//   Provides safe list utility functions.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+// ReSharper disable CheckNamespace
+namespace Microsoft.Security.Application
+    // ReSharper restore CheckNamespace
+{
+    using System.Collections;
+    using System.Globalization;
+
+    /// <summary>
+    /// Provides safe list utility functions.
+    /// </summary>
+    internal static class SafeList
+    {
+        /// <summary>
+        /// Generates a safe character array representing the specified value.
+        /// </summary>
+        /// <returns>A safe character array representing the specified value.</returns>
+        /// <param name="value">The value to generate a safe representation for.</param>
+        internal delegate char[] GenerateSafeValue(int value);
+
+        /// <summary>
+        /// Generates a new safe list of the specified size, using the specified function to produce safe values.
+        /// </summary>
+        /// <param name="length">The length of the safe list to generate.</param>
+        /// <param name="generateSafeValue">The <see cref="GenerateSafeValue"/> function to use.</param>
+        /// <returns>A new safe list.</returns>
+        internal static char[][] Generate(int length, GenerateSafeValue generateSafeValue)
+        {
+            char[][] allCharacters = new char[length + 1][];
+            for (int i = 0; i <= length; i++)
+            {
+                allCharacters[i] = generateSafeValue(i);
+            }
+
+            return allCharacters;
+        }
+
+        /// <summary>
+        /// Marks characters from the specified languages as safe.
+        /// </summary>
+        /// <param name="safeList">The safe list to punch holes in.</param>
+        /// <param name="lowerCodeCharts">The combination of lower code charts to use.</param>
+        /// <param name="lowerMidCodeCharts">The combination of lower mid code charts to use.</param>
+        /// <param name="midCodeCharts">The combination of mid code charts to use.</param>
+        /// <param name="upperMidCodeCharts">The combination of upper mid code charts to use.</param>
+        /// <param name="upperCodeCharts">The combination of upper code charts to use.</param>
+        internal static void PunchUnicodeThrough(
+            ref char[][] safeList,
+            LowerCodeCharts lowerCodeCharts, 
+            LowerMidCodeCharts lowerMidCodeCharts, 
+            MidCodeCharts midCodeCharts, 
+            UpperMidCodeCharts upperMidCodeCharts, 
+            UpperCodeCharts upperCodeCharts)
+        {
+            if (lowerCodeCharts != LowerCodeCharts.None)
+            {
+                PunchCodeCharts(ref safeList, lowerCodeCharts);
+            }
+
+            if (lowerMidCodeCharts != LowerMidCodeCharts.None)
+            {
+                PunchCodeCharts(ref safeList, lowerMidCodeCharts);
+            }
+
+            if (midCodeCharts != MidCodeCharts.None)
+            {
+                PunchCodeCharts(ref safeList, midCodeCharts);
+            }
+
+            if (upperMidCodeCharts != UpperMidCodeCharts.None)
+            {
+                PunchCodeCharts(ref safeList, upperMidCodeCharts);
+            }
+
+            if (upperCodeCharts != UpperCodeCharts.None)
+            {
+                PunchCodeCharts(ref safeList, upperCodeCharts);
+            }
+        }
+
+        /// <summary>
+        /// Punches holes as necessary.
+        /// </summary>
+        /// <param name="safeList">The safe list to punch through.</param>
+        /// <param name="whiteListedCharacters">The list of character positions to punch.</param>
+        internal static void PunchSafeList(ref char[][] safeList, IEnumerable whiteListedCharacters)
+        {
+            PunchHolesIfNeeded(ref safeList, true, whiteListedCharacters);
+        }
+
+        /// <summary>
+        /// Generates a hash prefixed character array representing the specified value.
+        /// </summary>
+        /// <param name="value">The source value.</param>
+        /// <returns>A character array representing the specified value.</returns>
+        /// <remarks>
+        /// Example inputs and encoded outputs:
+        /// <list type="table">
+        /// <item><term>1</term><description>#1</description></item>
+        /// <item><term>10</term><description>#10</description></item>
+        /// <item><term>100</term><description>#100</description></item>
+        /// </list>
+        /// </remarks>
+        internal static char[] HashThenValueGenerator(int value)
+        {
+            return StringToCharArrayWithHashPrefix(value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Generates a hash prefixed character array representing the specified value in hexadecimal.
+        /// </summary>
+        /// <param name="value">The source value.</param>
+        /// <returns>A character array representing the specified value.</returns>
+        /// <remarks>
+        /// Example inputs and encoded outputs:
+        /// <list type="table">
+        /// <item><term>1</term><description>#1</description></item>
+        /// <item><term>10</term><description>#0a</description></item>
+        /// <item><term>100</term><description>#64</description></item>
+        /// </list>
+        /// </remarks>
+        internal static char[] HashThenHexValueGenerator(int value)
+        {
+            return StringToCharArrayWithHashPrefix(value.ToString("X2", CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Generates a percent prefixed character array representing the specified value in hexadecimal.
+        /// </summary>
+        /// <param name="value">The source value.</param>
+        /// <returns>A character array representing the specified value.</returns>
+        /// <remarks>
+        /// Example inputs and encoded outputs:
+        /// <list type="table">
+        /// <item><term>1</term><description>%01</description></item>
+        /// <item><term>10</term><description>%0a</description></item>
+        /// <item><term>100</term><description>%64</description></item>
+        /// </list>
+        /// </remarks>
+        internal static char[] PercentThenHexValueGenerator(int value)
+        {
+            return StringToCharArrayWithPercentPrefix(value.ToString("x2", CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Generates a slash prefixed character array representing the specified value in hexadecimal.
+        /// </summary>
+        /// <param name="value">The source value.</param>
+        /// <returns>A character array representing the specified value.</returns>
+        /// <remarks>
+        /// Example inputs and encoded outputs:
+        /// <list type="table">
+        /// <item><term>1</term><description>\01</description></item>
+        /// <item><term>10</term><description>\0a</description></item>
+        /// <item><term>100</term><description>\64</description></item>
+        /// </list>
+        /// </remarks>
+        internal static char[] SlashThenHexValueGenerator(int value)
+        {
+            return StringToCharArrayWithSlashPrefix(value.ToString("x2", CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Generates a slash prefixed character array representing the specified value in hexadecimal.
+        /// </summary>
+        /// <param name="value">The source value.</param>
+        /// <returns>A character array representing the specified value.</returns>
+        /// <remarks>
+        /// Example inputs and encoded outputs:
+        /// <list type="table">
+        /// <item><term>1</term><description>\000001</description></item>
+        /// <item><term>10</term><description>\000000A</description></item>
+        /// <item><term>100</term><description>\000064</description></item>
+        /// </list>
+        /// </remarks>
+        internal static char[] SlashThenSixDigitHexValueGenerator(int value)
+        {
+            return StringToCharArrayWithSlashPrefix(value.ToString("X6", CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Generates a hash prefixed character array from the specified string.
+        /// </summary>
+        /// <param name="value">The source value.</param>
+        /// <returns>A character array representing the specified value.</returns>
+        /// <remarks>
+        /// Example inputs and encoded outputs:
+        /// <list type="table">
+        /// <item><term>1</term><description>#1</description></item>
+        /// <item><term>10</term><description>#10</description></item>
+        /// <item><term>100</term><description>#100</description></item>
+        /// </list>
+        /// </remarks>
+        private static char[] StringToCharArrayWithHashPrefix(string value)
+        {
+            return StringToCharArrayWithPrefix(value, '#');            
+        }
+
+        /// <summary>
+        /// Generates a percent prefixed character array from the specified string.
+        /// </summary>
+        /// <param name="value">The source value.</param>
+        /// <returns>A character array representing the specified value.</returns>
+        /// <remarks>
+        /// Example inputs and encoded outputs:
+        /// <list type="table">
+        /// <item><term>1</term><description>%1</description></item>
+        /// <item><term>10</term><description>%10</description></item>
+        /// <item><term>100</term><description>%100</description></item>
+        /// </list>
+        /// </remarks>
+        private static char[] StringToCharArrayWithPercentPrefix(string value)
+        {
+            return StringToCharArrayWithPrefix(value, '%');            
+        }
+
+        /// <summary>
+        /// Generates a slash prefixed character array from the specified string.
+        /// </summary>
+        /// <param name="value">The source value.</param>
+        /// <returns>A character array representing the specified value.</returns>
+        /// <remarks>
+        /// Example inputs and encoded outputs:
+        /// <list type="table">
+        /// <item><term>1</term><description>\1</description></item>
+        /// <item><term>10</term><description>\10</description></item>
+        /// <item><term>100</term><description>\100</description></item>
+        /// </list>
+        /// </remarks>
+        private static char[] StringToCharArrayWithSlashPrefix(string value)
+        {
+            return StringToCharArrayWithPrefix(value, '\\');
+        }
+
+        /// <summary>
+        /// Generates a prefixed character array from the specified string and prefix.
+        /// </summary>
+        /// <param name="value">The source value.</param>
+        /// <param name="prefix">The prefix to use.</param>
+        /// <returns>A prefixed character array representing the specified value.</returns>
+        private static char[] StringToCharArrayWithPrefix(string value, char prefix)
+        {
+            int valueAsStringLength = value.Length;
+
+            char[] valueAsCharArray = new char[valueAsStringLength + 1];
+            valueAsCharArray[0] = prefix;
+            for (int j = 0; j < valueAsStringLength; j++)
+            {
+                valueAsCharArray[j + 1] = value[j];
+            }
+
+            return valueAsCharArray;
+        }
+
+        /// <summary>
+        /// Punch appropriate holes for the selected code charts.
+        /// </summary>
+        /// <param name="safeList">The safe list to punch through.</param>
+        /// <param name="codeCharts">The code charts to punch.</param>
+        private static void PunchCodeCharts(ref char[][] safeList, LowerCodeCharts codeCharts)
+        {
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.BasicLatin), CodeCharts.Lower.BasicLatin());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.C1ControlsAndLatin1Supplement), CodeCharts.Lower.Latin1Supplement());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.LatinExtendedA), CodeCharts.Lower.LatinExtendedA());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.LatinExtendedB), CodeCharts.Lower.LatinExtendedB());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.IpaExtensions), CodeCharts.Lower.IpaExtensions());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.SpacingModifierLetters), CodeCharts.Lower.SpacingModifierLetters());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.CombiningDiacriticalMarks), CodeCharts.Lower.CombiningDiacriticalMarks());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.GreekAndCoptic), CodeCharts.Lower.GreekAndCoptic());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Cyrillic), CodeCharts.Lower.Cyrillic());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.CyrillicSupplement), CodeCharts.Lower.CyrillicSupplement());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Armenian), CodeCharts.Lower.Armenian());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Hebrew), CodeCharts.Lower.Hebrew());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Arabic), CodeCharts.Lower.Arabic());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Syriac), CodeCharts.Lower.Syriac());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.ArabicSupplement), CodeCharts.Lower.ArabicSupplement());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Thaana), CodeCharts.Lower.Thaana());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Nko), CodeCharts.Lower.Nko());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Samaritan), CodeCharts.Lower.Samaritan());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Devanagari), CodeCharts.Lower.Devanagari());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Bengali), CodeCharts.Lower.Bengali());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Gurmukhi), CodeCharts.Lower.Gurmukhi());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Gujarati), CodeCharts.Lower.Gujarati());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Oriya), CodeCharts.Lower.Oriya());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Tamil), CodeCharts.Lower.Tamil());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Telugu), CodeCharts.Lower.Telugu());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Kannada), CodeCharts.Lower.Kannada());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Malayalam), CodeCharts.Lower.Malayalam());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Sinhala), CodeCharts.Lower.Sinhala());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Thai), CodeCharts.Lower.Thai());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Lao), CodeCharts.Lower.Lao());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Lower.IsFlagSet(codeCharts, LowerCodeCharts.Tibetan), CodeCharts.Lower.Tibetan());
+        }
+
+        /// <summary>
+        /// Punch appropriate holes for the selected code charts.
+        /// </summary>
+        /// <param name="safeList">The safe list to punch through.</param>
+        /// <param name="codeCharts">The code charts to punch.</param>
+        private static void PunchCodeCharts(ref char[][] safeList, LowerMidCodeCharts codeCharts)
+        {
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Myanmar), CodeCharts.LowerMiddle.Myanmar());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Georgian), CodeCharts.LowerMiddle.Georgian());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.HangulJamo), CodeCharts.LowerMiddle.HangulJamo());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Ethiopic), CodeCharts.LowerMiddle.Ethiopic());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.EthiopicSupplement), CodeCharts.LowerMiddle.EthiopicSupplement());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Cherokee), CodeCharts.LowerMiddle.Cherokee());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.UnifiedCanadianAboriginalSyllabics), CodeCharts.LowerMiddle.UnifiedCanadianAboriginalSyllabics());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Ogham), CodeCharts.LowerMiddle.Ogham());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Runic), CodeCharts.LowerMiddle.Runic());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Tagalog), CodeCharts.LowerMiddle.Tagalog());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Hanunoo), CodeCharts.LowerMiddle.Hanunoo());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Buhid), CodeCharts.LowerMiddle.Buhid());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Tagbanwa), CodeCharts.LowerMiddle.Tagbanwa());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Khmer), CodeCharts.LowerMiddle.Khmer());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Mongolian), CodeCharts.LowerMiddle.Mongolian());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.UnifiedCanadianAboriginalSyllabicsExtended), CodeCharts.LowerMiddle.UnifiedCanadianAboriginalSyllabicsExtended());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Limbu), CodeCharts.LowerMiddle.Limbu());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.TaiLe), CodeCharts.LowerMiddle.TaiLe());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.NewTaiLue), CodeCharts.LowerMiddle.NewTaiLue());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.KhmerSymbols), CodeCharts.LowerMiddle.KhmerSymbols());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Buginese), CodeCharts.LowerMiddle.Buginese());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.TaiTham), CodeCharts.LowerMiddle.TaiTham());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Balinese), CodeCharts.LowerMiddle.Balinese());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Sudanese), CodeCharts.LowerMiddle.Sudanese());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.Lepcha), CodeCharts.LowerMiddle.Lepcha());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.OlChiki), CodeCharts.LowerMiddle.OlChiki());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.VedicExtensions), CodeCharts.LowerMiddle.VedicExtensions());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.PhoneticExtensions), CodeCharts.LowerMiddle.PhoneticExtensions());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.PhoneticExtensionsSupplement), CodeCharts.LowerMiddle.PhoneticExtensionsSupplement());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.CombiningDiacriticalMarksSupplement), CodeCharts.LowerMiddle.CombiningDiacriticalMarksSupplement());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.LowerMiddle.IsFlagSet(codeCharts, LowerMidCodeCharts.LatinExtendedAdditional), CodeCharts.LowerMiddle.LatinExtendedAdditional());
+        }
+
+        /// <summary>
+        /// Punch appropriate holes for the selected code charts.
+        /// </summary>
+        /// <param name="safeList">The safe list to punch through.</param>
+        /// <param name="codeCharts">The code charts to punch.</param>
+        private static void PunchCodeCharts(ref char[][] safeList, MidCodeCharts codeCharts)
+        {
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.GreekExtended), CodeCharts.Middle.GreekExtended());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.GeneralPunctuation), CodeCharts.Middle.GeneralPunctuation());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.SuperscriptsAndSubscripts), CodeCharts.Middle.SuperscriptsAndSubscripts());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.CurrencySymbols), CodeCharts.Middle.CurrencySymbols());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.CombiningDiacriticalMarksForSymbols), CodeCharts.Middle.CombiningDiacriticalMarksForSymbols());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.LetterlikeSymbols), CodeCharts.Middle.LetterlikeSymbols());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.NumberForms), CodeCharts.Middle.NumberForms());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.Arrows), CodeCharts.Middle.Arrows());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.MathematicalOperators), CodeCharts.Middle.MathematicalOperators());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.MiscellaneousTechnical), CodeCharts.Middle.MiscellaneousTechnical());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.ControlPictures), CodeCharts.Middle.ControlPictures());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.OpticalCharacterRecognition), CodeCharts.Middle.OpticalCharacterRecognition());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.EnclosedAlphanumerics), CodeCharts.Middle.EnclosedAlphanumerics());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.BoxDrawing), CodeCharts.Middle.BoxDrawing());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.BlockElements), CodeCharts.Middle.BlockElements());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.GeometricShapes), CodeCharts.Middle.GeometricShapes());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.MiscellaneousSymbols), CodeCharts.Middle.MiscellaneousSymbols());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.Dingbats), CodeCharts.Middle.Dingbats());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.MiscellaneousMathematicalSymbolsA), CodeCharts.Middle.MiscellaneousMathematicalSymbolsA());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.SupplementalArrowsA), CodeCharts.Middle.SupplementalArrowsA());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.BraillePatterns), CodeCharts.Middle.BraillePatterns());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.SupplementalArrowsB), CodeCharts.Middle.SupplementalArrowsB());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.MiscellaneousMathematicalSymbolsB), CodeCharts.Middle.MiscellaneousMathematicalSymbolsB());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.SupplementalMathematicalOperators), CodeCharts.Middle.SupplementalMathematicalOperators());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.MiscellaneousSymbolsAndArrows), CodeCharts.Middle.MiscellaneousSymbolsAndArrows());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.Glagolitic), CodeCharts.Middle.Glagolitic());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.LatinExtendedC), CodeCharts.Middle.LatinExtendedC());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.Coptic), CodeCharts.Middle.Coptic());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.GeorgianSupplement), CodeCharts.Middle.GeorgianSupplement());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.Tifinagh), CodeCharts.Middle.Tifinagh());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Middle.IsFlagSet(codeCharts, MidCodeCharts.EthiopicExtended), CodeCharts.Middle.EthiopicExtended());
+        }
+
+        /// <summary>
+        /// Punch appropriate holes for the selected code charts.
+        /// </summary>
+        /// <param name="safeList">The safe list to punch through.</param>
+        /// <param name="codeCharts">The code charts to punch.</param>
+        private static void PunchCodeCharts(ref char[][] safeList, UpperMidCodeCharts codeCharts)
+        {
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.CyrillicExtendedA), CodeCharts.UpperMiddle.CyrillicExtendedA());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.SupplementalPunctuation), CodeCharts.UpperMiddle.SupplementalPunctuation());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.CjkRadicalsSupplement), CodeCharts.UpperMiddle.CjkRadicalsSupplement());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.KangxiRadicals), CodeCharts.UpperMiddle.KangxiRadicals());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.IdeographicDescriptionCharacters), CodeCharts.UpperMiddle.IdeographicDescriptionCharacters());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.CjkSymbolsAndPunctuation), CodeCharts.UpperMiddle.CjkSymbolsAndPunctuation());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.Hiragana), CodeCharts.UpperMiddle.Hiragana());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.Katakana), CodeCharts.UpperMiddle.Katakana());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.Bopomofo), CodeCharts.UpperMiddle.Bopomofo());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.HangulCompatibilityJamo), CodeCharts.UpperMiddle.HangulCompatibilityJamo());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.Kanbun), CodeCharts.UpperMiddle.Kanbun());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.BopomofoExtended), CodeCharts.UpperMiddle.BopomofoExtended());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.CjkStrokes), CodeCharts.UpperMiddle.CjkStrokes());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.KatakanaPhoneticExtensions), CodeCharts.UpperMiddle.KatakanaPhoneticExtensions());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.EnclosedCjkLettersAndMonths), CodeCharts.UpperMiddle.EnclosedCjkLettersAndMonths());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.CjkCompatibility), CodeCharts.UpperMiddle.CjkCompatibility());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.CjkUnifiedIdeographsExtensionA), CodeCharts.UpperMiddle.CjkUnifiedIdeographsExtensionA());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.YijingHexagramSymbols), CodeCharts.UpperMiddle.YijingHexagramSymbols());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.CjkUnifiedIdeographs), CodeCharts.UpperMiddle.CjkUnifiedIdeographs());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.YiSyllables), CodeCharts.UpperMiddle.YiSyllables());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.YiRadicals), CodeCharts.UpperMiddle.YiRadicals());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.Lisu), CodeCharts.UpperMiddle.Lisu());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.Vai), CodeCharts.UpperMiddle.Vai());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.CyrillicExtendedB), CodeCharts.UpperMiddle.CyrillicExtendedB());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.Bamum), CodeCharts.UpperMiddle.Bamum());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.ModifierToneLetters), CodeCharts.UpperMiddle.ModifierToneLetters());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.LatinExtendedD), CodeCharts.UpperMiddle.LatinExtendedD());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.SylotiNagri), CodeCharts.UpperMiddle.SylotiNagri());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.CommonIndicNumberForms), CodeCharts.UpperMiddle.CommonIndicNumberForms());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.Phagspa), CodeCharts.UpperMiddle.Phagspa());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.UpperMiddle.IsFlagSet(codeCharts, UpperMidCodeCharts.Saurashtra), CodeCharts.UpperMiddle.Saurashtra());
+        }
+
+        /// <summary>
+        /// Punch appropriate holes for the selected code charts.
+        /// </summary>
+        /// <param name="safeList">The safe list to punch through.</param>
+        /// <param name="codeCharts">The code charts to punch.</param>
+        private static void PunchCodeCharts(ref char[][] safeList, UpperCodeCharts codeCharts)
+        {
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.DevanagariExtended), CodeCharts.Upper.DevanagariExtended());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.KayahLi), CodeCharts.Upper.KayahLi());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.Rejang), CodeCharts.Upper.Rejang());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.HangulJamoExtendedA), CodeCharts.Upper.HangulJamoExtendedA());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.Javanese), CodeCharts.Upper.Javanese());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.Cham), CodeCharts.Upper.Cham());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.MyanmarExtendedA), CodeCharts.Upper.MyanmarExtendedA());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.TaiViet), CodeCharts.Upper.TaiViet());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.MeeteiMayek), CodeCharts.Upper.MeeteiMayek());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.HangulSyllables), CodeCharts.Upper.HangulSyllables());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.HangulJamoExtendedB), CodeCharts.Upper.HangulJamoExtendedB());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.CjkCompatibilityIdeographs), CodeCharts.Upper.CjkCompatibilityIdeographs());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.AlphabeticPresentationForms), CodeCharts.Upper.AlphabeticPresentationForms());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.ArabicPresentationFormsA), CodeCharts.Upper.ArabicPresentationFormsA());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.VariationSelectors), CodeCharts.Upper.VariationSelectors());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.VerticalForms), CodeCharts.Upper.VerticalForms());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.CombiningHalfMarks), CodeCharts.Upper.CombiningHalfMarks());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.CjkCompatibilityForms), CodeCharts.Upper.CjkCompatibilityForms());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.SmallFormVariants), CodeCharts.Upper.SmallFormVariants());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.ArabicPresentationFormsB), CodeCharts.Upper.ArabicPresentationFormsB());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.HalfWidthAndFullWidthForms), CodeCharts.Upper.HalfWidthAndFullWidthForms());
+            PunchHolesIfNeeded(ref safeList, CodeCharts.Upper.IsFlagSet(codeCharts, UpperCodeCharts.Specials), CodeCharts.Upper.Specials());
+        }
+
+        /// <summary>
+        /// Punches holes as necessary.
+        /// </summary>
+        /// <param name="safeList">The safe list to punch through.</param>
+        /// <param name="needed">Value indicating whether the holes should be punched.</param>
+        /// <param name="whiteListedCharacters">The list of character positions to punch.</param>
+        private static void PunchHolesIfNeeded(ref char[][] safeList, bool needed, IEnumerable whiteListedCharacters)
+        {
+            if (!needed)
+            {
+                return;
+            }
+
+            foreach (int offset in whiteListedCharacters)
+            {
+                safeList[offset] = null;
+            }
+        }
+    }
+}

--- a/source/Core/Internal/AntiXssLibrary/UnicodeCharacterEncoder.cs
+++ b/source/Core/Internal/AntiXssLibrary/UnicodeCharacterEncoder.cs
@@ -1,0 +1,743 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="UnicodeCharacterEncoder.cs" company="Microsoft Corporation">
+//   Copyright (c) 2008, 2009, 2010 All Rights Reserved, Microsoft Corporation
+//
+//   This source is subject to the Microsoft Permissive License.
+//   Please see the License.txt file for more information.
+//   All other rights reserved.
+//
+//   THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+//   KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//   IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//   PARTICULAR PURPOSE.
+//
+// </copyright>
+// <summary>
+//   Provides HTML Encoding methods.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+// ReSharper disable CheckNamespace
+namespace Microsoft.Security.Application
+    // ReSharper restore CheckNamespace
+{
+    using System;
+    using System.Text;
+    using System.Threading;
+
+    /// <summary>
+    /// Provides HTML encoding methods.
+    /// </summary>
+    public static class UnicodeCharacterEncoder
+    {
+        /// <summary>
+        /// The HTML escaped value for a space, used in attribute encoding.
+        /// </summary>
+        private static readonly char[] UnicodeSpace = "&#32;".ToCharArray();
+
+        /// <summary>
+        /// The Unicode value for an apostrophe, used in attribute encoding.
+        /// </summary>
+        private static readonly char[] UnicodeApostrophe = "&#39;".ToCharArray();
+
+        /// <summary>
+        /// The XML named entity for an apostrophe, used in XML encoding.
+        /// </summary>
+        private static readonly char[] XmlApostrophe = "&apos;".ToCharArray();
+
+        /// <summary>
+        /// The current lower code chart settings.
+        /// </summary>
+        private static LowerCodeCharts currentLowerCodeChartSettings = LowerCodeCharts.Default;
+
+        /// <summary>
+        /// The current lower middle code chart settings.
+        /// </summary>
+        private static LowerMidCodeCharts currentLowerMidCodeChartSettings = LowerMidCodeCharts.None;
+
+        /// <summary>
+        /// The current middle code chart settings.
+        /// </summary>
+        private static MidCodeCharts currentMidCodeChartSettings = MidCodeCharts.None;
+
+        /// <summary>
+        /// The current upper middle code chart settings.
+        /// </summary>
+        private static UpperMidCodeCharts currentUpperMidCodeChartSettings = UpperMidCodeCharts.None;
+
+        /// <summary>
+        /// The current upper code chart settings.
+        /// </summary>
+        private static UpperCodeCharts currentUpperCodeChartSettings = UpperCodeCharts.None;
+
+        /// <summary>
+        /// The values to output for each character.
+        /// </summary>
+        private static char[][] characterValues;
+
+        /// <summary>
+        /// The values to output for HTML named entities.
+        /// </summary>
+        private static Lazy<char[][]> namedEntitiesLazy = new Lazy<char[][]>(InitialiseNamedEntityList);
+
+#if NET20
+        /// <summary>
+        /// Lock object
+        /// </summary>
+        private static readonly ReaderWriterLock SyncLock = new ReaderWriterLock();
+  
+        /// <summary>
+        /// Acquires a read lock.
+        /// </summary>
+        private static void AcquireReadLock() 
+        {
+            SyncLock.AcquireReaderLock(-1);
+        }
+        
+        /// <summary>
+        /// Releases a read lock.
+        /// </summary>
+        private static void ReleaseReadLock()
+        {
+            SyncLock.ReleaseReaderLock();
+        }
+
+        /// <summary>
+        /// Acquires a write lock.
+        /// </summary>
+        private static void AcquireWriteLock()
+        {
+            SyncLock.AcquireWriterLock(-1);
+        }
+
+        /// <summary>
+        /// Releases a write lock.
+        /// </summary>        
+        private static void ReleaseWriteLock()
+        {
+            SyncLock.ReleaseWriterLock();
+        }
+#else
+        /// <summary>
+        /// Lock object
+        /// </summary>
+        private static readonly ReaderWriterLockSlim SyncLock = new ReaderWriterLockSlim();
+  
+        /// <summary>
+        /// Acquires a read lock.
+        /// </summary>
+        private static void AcquireReadLock() 
+        {
+            SyncLock.EnterReadLock();
+        }
+
+        /// <summary>
+        /// Releases a read lock.
+        /// </summary>
+        private static void ReleaseReadLock()
+        {
+            SyncLock.ExitReadLock();
+        }
+
+        /// <summary>
+        /// Acquires a write lock.
+        /// </summary>
+        private static void AcquireWriteLock()
+        {
+            SyncLock.EnterWriteLock();
+        }
+
+        /// <summary>
+        /// Releases a write lock.
+        /// </summary>
+        private static void ReleaseWriteLock()
+        {
+            SyncLock.ExitWriteLock();
+        }
+#endif
+
+        /// <summary>
+        /// Provides method specific encoding of characters.
+        /// </summary>
+        /// <param name="input">The character to encode</param>
+        /// <param name="output">The encoded character, if it has been encoded.</param>
+        /// <returns>True if the character has been encoded, otherwise false.</returns>
+        private delegate bool MethodSpecificEncoder(char input, out char[] output);
+
+        /// <summary>
+        /// Marks characters from the specified languages as safe.
+        /// </summary>
+        /// <param name="lowerCodeCharts">The combination of lower code charts to use.</param>
+        /// <param name="lowerMidCodeCharts">The combination of lower mid code charts to use.</param>
+        /// <param name="midCodeCharts">The combination of mid code charts to use.</param>
+        /// <param name="upperMidCodeCharts">The combination of upper mid code charts to use.</param>
+        /// <param name="upperCodeCharts">The combination of upper code charts to use.</param>
+        /// <remarks>The safe list affects all HTML and XML encoding functions.</remarks>
+        public static void MarkAsSafe(
+            LowerCodeCharts lowerCodeCharts,
+            LowerMidCodeCharts lowerMidCodeCharts,
+            MidCodeCharts midCodeCharts,
+            UpperMidCodeCharts upperMidCodeCharts,
+            UpperCodeCharts upperCodeCharts)
+        {
+            if (lowerCodeCharts == currentLowerCodeChartSettings
+                && lowerMidCodeCharts == currentLowerMidCodeChartSettings
+                && midCodeCharts == currentMidCodeChartSettings
+                && upperMidCodeCharts == currentUpperMidCodeChartSettings
+                && upperCodeCharts == currentUpperCodeChartSettings)
+            {
+                return;
+            }
+
+            AcquireWriteLock();
+            try
+            {
+                // Reset back to everything hashed.
+                characterValues = SafeList.Generate(65536, SafeList.HashThenValueGenerator);
+
+                SafeList.PunchUnicodeThrough(
+                    ref characterValues,
+                    lowerCodeCharts,
+                    lowerMidCodeCharts,
+                    midCodeCharts,
+                    upperMidCodeCharts,
+                    upperCodeCharts);
+
+                ApplyHtmlSpecificValues();
+
+                currentLowerCodeChartSettings = lowerCodeCharts;
+                currentLowerMidCodeChartSettings = lowerMidCodeCharts;
+                currentMidCodeChartSettings = midCodeCharts;
+                currentUpperMidCodeChartSettings = upperMidCodeCharts;
+                currentUpperCodeChartSettings = upperCodeCharts;
+            }
+            finally
+            {
+                ReleaseWriteLock();
+            }
+        }
+
+        /// <summary>
+        /// Encodes input strings for use in XML.
+        /// </summary>
+        /// <param name="input">String to be encoded</param>
+        /// <returns>
+        /// Encoded string for use in XML.
+        /// </returns>
+        internal static string XmlEncode(string input)
+        {
+            return HtmlEncode(input, false, XmlTweak);
+        }
+
+        /// <summary>
+        /// Encodes input strings for use in XML.
+        /// </summary>
+        /// <param name="input">String to be encoded</param>
+        /// <returns>
+        /// Encoded string for use in XML.
+        /// </returns>
+        internal static string XmlAttributeEncode(string input)
+        {
+            return HtmlEncode(input, false, XmlAttributeTweak);
+        }
+
+        /// <summary>
+        /// Encodes input strings for use in HTML attributes.
+        /// </summary>
+        /// <param name="input">String to be encoded</param>
+        /// <returns>
+        /// Encoded string for use in HTML attributes.
+        /// </returns>
+        internal static string HtmlAttributeEncode(string input)
+        {
+            return HtmlEncode(input, false, HtmlAttributeTweak);
+        }
+
+        /// <summary>
+        /// Encodes input strings for use in HTML.
+        /// </summary>
+        /// <param name="input">String to be encoded</param>
+        /// <param name="useNamedEntities">Value indicating if the HTML 4.0 named entities should be used.</param>
+        /// <returns>
+        /// Encoded string for use in HTML.
+        /// </returns>
+        internal static string HtmlEncode(string input, bool useNamedEntities)
+        {
+            return HtmlEncode(input, useNamedEntities, null);
+        }
+
+        /// <summary>
+        /// Applies Html specific values to the internal value list.
+        /// </summary>
+        /// <remarks>
+        /// ASP.NET 4 and Razor introduced a new syntax &lt;%: %&gt; and @ which are used to HTML-encode values.
+        /// For example, &lt;%: foo %&gt; is shorthand for &lt;%= HttpUtility.HtmlEncode(foo) %&gt;. Since these could
+        /// occur inside an attribute, e.g. &lt;a href="@Foo"&gt;, ASP.NET mandates that HtmlEncode also encode
+        /// characters that are meaningful inside HTML attributes, like the single quote. Encoding spaces
+        /// isn't mandatory since it's expected that users will surround such variables with quotes.
+        /// </remarks>
+        private static void ApplyHtmlSpecificValues()
+        {
+            characterValues['<'] = "lt".ToCharArray();
+            characterValues['>'] = "gt".ToCharArray();
+            characterValues['&'] = "amp".ToCharArray();
+            characterValues['"'] = "quot".ToCharArray();
+            characterValues['\''] = "#39".ToCharArray();
+        }
+
+        /// <summary>
+        /// HTML Attribute Encoding specific tweaks.
+        /// </summary>
+        /// <param name="input">The character to potentially encode.</param>
+        /// <param name="output">The encoded character, if any.</param>
+        /// <returns>True if encoding took place, otherwise false.</returns>
+        private static bool HtmlAttributeTweak(char input, out char[] output)
+        {
+            if (input == '\'')
+            {
+                output = UnicodeApostrophe;
+                return true;
+            }
+
+            if (input == ' ')
+            {
+                output = UnicodeSpace;
+                return true;
+            }
+
+            output = null;
+            return false;
+        }
+
+        /// <summary>
+        /// XML specific tweaks.
+        /// </summary>
+        /// <param name="input">The character to potentially encode.</param>
+        /// <param name="output">The encoded character, if any.</param>
+        /// <returns>True if encoding took place, otherwise false.</returns>
+        private static bool XmlTweak(char input, out char[] output)
+        {
+            if (input == '\'')
+            {
+                output = XmlApostrophe;
+                return true;
+            }
+
+            output = null;
+            return false;
+        }
+
+        /// <summary>
+        /// XML Attribute Encoding specific tweaks.
+        /// </summary>
+        /// <param name="input">The character to potentially encode.</param>
+        /// <param name="output">The encoded character, if any.</param>
+        /// <returns>True if encoding took place, otherwise false.</returns>
+        private static bool XmlAttributeTweak(char input, out char[] output)
+        {
+            if (input == '\'')
+            {
+                output = XmlApostrophe;
+                return true;
+            }
+
+            if (input == ' ')
+            {
+                output = UnicodeSpace;
+                return true;
+            }
+
+            output = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Encodes input strings for use in HTML.
+        /// </summary>
+        /// <param name="input">String to be encoded</param>
+        /// <param name="useNamedEntities">Value indicating if the HTML 4.0 named entities should be used.</param>
+        /// <param name="encoderTweak">A <see cref="MethodSpecificEncoder"/> function, if needed.</param>
+        /// <returns>
+        /// Encoded string for use in HTML.
+        /// </returns>
+        private static string HtmlEncode(string input, bool useNamedEntities, MethodSpecificEncoder encoderTweak)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return input;
+            }
+
+            if (characterValues == null)
+            {
+                InitialiseSafeList();
+            }
+
+            char[][] namedEntities = null;
+            if (useNamedEntities)
+            {
+                namedEntities = namedEntitiesLazy.Value;
+            }
+
+            // Setup a new StringBuilder for output.
+            // Worse case scenario - the longest entity name, thetasym is 10 characters, including the & and ;.
+            StringBuilder builder = EncoderUtil.GetOutputStringBuilder(input.Length, 10);
+            
+            AcquireReadLock();
+            try
+            {
+                Utf16StringReader stringReader = new Utf16StringReader(input);
+                while (true)
+                {
+                    int currentCodePoint = stringReader.ReadNextScalarValue();
+                    if (currentCodePoint < 0)
+                    {
+                        break; // EOF
+                    }
+
+                    if (currentCodePoint > char.MaxValue)
+                    {
+                        // We don't have a pre-generated mapping of characters beyond the Basic Multilingual
+                        // Plane (BMP), so we need to generate these encodings on-the-fly. We should encode
+                        // the code point rather than the surrogate code units that make up this code point.
+                        // See: http://www.w3.org/International/questions/qa-escapes#bytheway
+                        char[] encodedCharacter = SafeList.HashThenValueGenerator(currentCodePoint);
+                        builder.Append('&');
+                        builder.Append(encodedCharacter);
+                        builder.Append(';');
+                    }
+                    else
+                    {
+                        // If we reached this point, the code point is within the BMP.
+                        char currentCharacter = (char)currentCodePoint;
+                        char[] tweekedValue;
+
+                        if (encoderTweak != null && encoderTweak(currentCharacter, out tweekedValue))
+                        {
+                            builder.Append(tweekedValue);
+                        }
+                        else if (useNamedEntities && namedEntities[currentCodePoint] != null)
+                        {
+                            char[] encodedCharacter = namedEntities[currentCodePoint];
+                            builder.Append('&');
+                            builder.Append(encodedCharacter);
+                            builder.Append(';');
+                        }
+                        else if (characterValues[currentCodePoint] != null)
+                        {
+                            // character needs to be encoded
+                            char[] encodedCharacter = characterValues[currentCodePoint];
+                            builder.Append('&');
+                            builder.Append(encodedCharacter);
+                            builder.Append(';');
+                        }
+                        else
+                        {
+                            // character does not need encoding
+                            builder.Append(currentCharacter);
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                ReleaseReadLock();
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Initializes the HTML safe list.
+        /// </summary>
+        private static void InitialiseSafeList()
+        {
+            AcquireWriteLock();
+            try
+            {
+                if (characterValues == null)
+                {
+                    // We use decimal encoding to support some older Japanese mobile browsers which don't support hex encoding.
+                    characterValues = SafeList.Generate(0xFFFF, SafeList.HashThenValueGenerator);
+                    SafeList.PunchUnicodeThrough(
+                        ref characterValues,
+                        currentLowerCodeChartSettings,
+                        currentLowerMidCodeChartSettings,
+                        currentMidCodeChartSettings,
+                        currentUpperMidCodeChartSettings,
+                        currentUpperCodeChartSettings);
+                    ApplyHtmlSpecificValues();
+                }
+            }
+            finally
+            {
+                ReleaseWriteLock();
+            }
+        }
+
+        /// <summary>
+        /// Initializes the HTML named entities list.
+        /// </summary>
+        /// <returns>The HTML named entities list.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Microsoft.Maintainability",
+            "CA1505:AvoidUnmaintainableCode",
+            Justification = "Splitting or initialising via lookups has too large a performance increase.")]
+        private static char[][] InitialiseNamedEntityList()
+        {
+            char[][] namedEntities = new char[65536][];
+            namedEntities[160] = "nbsp".ToCharArray();
+            namedEntities[161] = "iexcl".ToCharArray();
+            namedEntities[162] = "cent".ToCharArray();
+            namedEntities[163] = "pound".ToCharArray();
+            namedEntities[164] = "curren".ToCharArray();
+            namedEntities[165] = "yen".ToCharArray();
+            namedEntities[166] = "brvbar".ToCharArray();
+            namedEntities[167] = "sect".ToCharArray();
+            namedEntities[168] = "uml".ToCharArray();
+            namedEntities[169] = "copy".ToCharArray();
+            namedEntities[170] = "ordf".ToCharArray();
+            namedEntities[171] = "laquo".ToCharArray();
+            namedEntities[172] = "not".ToCharArray();
+            namedEntities[173] = "shy".ToCharArray();
+            namedEntities[174] = "reg".ToCharArray();
+            namedEntities[175] = "macr".ToCharArray();
+            namedEntities[176] = "deg".ToCharArray();
+            namedEntities[177] = "plusmn".ToCharArray();
+            namedEntities[178] = "sup2".ToCharArray();
+            namedEntities[179] = "sup3".ToCharArray();
+            namedEntities[180] = "acute".ToCharArray();
+            namedEntities[181] = "micro".ToCharArray();
+            namedEntities[182] = "para".ToCharArray();
+            namedEntities[183] = "middot".ToCharArray();
+            namedEntities[184] = "cedil".ToCharArray();
+            namedEntities[185] = "sup1".ToCharArray();
+            namedEntities[186] = "ordm".ToCharArray();
+            namedEntities[187] = "raquo".ToCharArray();
+            namedEntities[188] = "frac14".ToCharArray();
+            namedEntities[189] = "frac12".ToCharArray();
+            namedEntities[190] = "frac34".ToCharArray();
+            namedEntities[191] = "iquest".ToCharArray();
+            namedEntities[192] = "Agrave".ToCharArray();
+            namedEntities[193] = "Aacute".ToCharArray();
+            namedEntities[194] = "Acirc".ToCharArray();
+            namedEntities[195] = "Atilde".ToCharArray();
+            namedEntities[196] = "Auml".ToCharArray();
+            namedEntities[197] = "Aring".ToCharArray();
+            namedEntities[198] = "AElig".ToCharArray();
+            namedEntities[199] = "Ccedil".ToCharArray();
+            namedEntities[200] = "Egrave".ToCharArray();
+            namedEntities[201] = "Eacute".ToCharArray();
+            namedEntities[202] = "Ecirc".ToCharArray();
+            namedEntities[203] = "Euml".ToCharArray();
+            namedEntities[204] = "Igrave".ToCharArray();
+            namedEntities[205] = "Iacute".ToCharArray();
+            namedEntities[206] = "Icirc".ToCharArray();
+            namedEntities[207] = "Iuml".ToCharArray();
+            namedEntities[208] = "ETH".ToCharArray();
+            namedEntities[209] = "Ntilde".ToCharArray();
+            namedEntities[210] = "Ograve".ToCharArray();
+            namedEntities[211] = "Oacute".ToCharArray();
+            namedEntities[212] = "Ocirc".ToCharArray();
+            namedEntities[213] = "Otilde".ToCharArray();
+            namedEntities[214] = "Ouml".ToCharArray();
+            namedEntities[215] = "times".ToCharArray();
+            namedEntities[216] = "Oslash".ToCharArray();
+            namedEntities[217] = "Ugrave".ToCharArray();
+            namedEntities[218] = "Uacute".ToCharArray();
+            namedEntities[219] = "Ucirc".ToCharArray();
+            namedEntities[220] = "Uuml".ToCharArray();
+            namedEntities[221] = "Yacute".ToCharArray();
+            namedEntities[222] = "THORN".ToCharArray();
+            namedEntities[223] = "szlig".ToCharArray();
+            namedEntities[224] = "agrave".ToCharArray();
+            namedEntities[225] = "aacute".ToCharArray();
+            namedEntities[226] = "acirc".ToCharArray();
+            namedEntities[227] = "atilde".ToCharArray();
+            namedEntities[228] = "auml".ToCharArray();
+            namedEntities[229] = "aring".ToCharArray();
+            namedEntities[230] = "aelig".ToCharArray();
+            namedEntities[231] = "ccedil".ToCharArray();
+            namedEntities[232] = "egrave".ToCharArray();
+            namedEntities[233] = "eacute".ToCharArray();
+            namedEntities[234] = "ecirc".ToCharArray();
+            namedEntities[235] = "euml".ToCharArray();
+            namedEntities[236] = "igrave".ToCharArray();
+            namedEntities[237] = "iacute".ToCharArray();
+            namedEntities[238] = "icirc".ToCharArray();
+            namedEntities[239] = "iuml".ToCharArray();
+            namedEntities[240] = "eth".ToCharArray();
+            namedEntities[241] = "ntilde".ToCharArray();
+            namedEntities[242] = "ograve".ToCharArray();
+            namedEntities[243] = "oacute".ToCharArray();
+            namedEntities[244] = "ocirc".ToCharArray();
+            namedEntities[245] = "otilde".ToCharArray();
+            namedEntities[246] = "ouml".ToCharArray();
+            namedEntities[247] = "divide".ToCharArray();
+            namedEntities[248] = "oslash".ToCharArray();
+            namedEntities[249] = "ugrave".ToCharArray();
+            namedEntities[250] = "uacute".ToCharArray();
+            namedEntities[251] = "ucirc".ToCharArray();
+            namedEntities[252] = "uuml".ToCharArray();
+            namedEntities[253] = "yacute".ToCharArray();
+            namedEntities[254] = "thorn".ToCharArray();
+            namedEntities[255] = "yuml".ToCharArray();
+
+            namedEntities[338] = "OElig".ToCharArray();
+            namedEntities[339] = "oelig".ToCharArray();
+            namedEntities[352] = "Scaron".ToCharArray();
+            namedEntities[353] = "scaron".ToCharArray();
+            namedEntities[376] = "Yuml".ToCharArray();
+            namedEntities[402] = "fnof".ToCharArray();
+            namedEntities[710] = "circ".ToCharArray();
+            namedEntities[732] = "tilde".ToCharArray();
+
+            namedEntities[913] = "Alpha".ToCharArray();
+            namedEntities[914] = "Beta".ToCharArray();
+            namedEntities[915] = "Gamma".ToCharArray();
+            namedEntities[916] = "Delta".ToCharArray();
+            namedEntities[917] = "Epsilon".ToCharArray();
+            namedEntities[918] = "Zeta".ToCharArray();
+            namedEntities[919] = "Eta".ToCharArray();
+            namedEntities[920] = "Theta".ToCharArray();
+            namedEntities[921] = "Iota".ToCharArray();
+            namedEntities[922] = "Kappa".ToCharArray();
+            namedEntities[923] = "Lambda".ToCharArray();
+            namedEntities[924] = "Mu".ToCharArray();
+            namedEntities[925] = "Nu".ToCharArray();
+            namedEntities[926] = "Xi".ToCharArray();
+            namedEntities[927] = "Omicron".ToCharArray();
+            namedEntities[928] = "Pi".ToCharArray();
+            namedEntities[929] = "Rho".ToCharArray();
+            namedEntities[931] = "Sigma".ToCharArray();
+            namedEntities[932] = "Tau".ToCharArray();
+            namedEntities[933] = "Upsilon".ToCharArray();
+            namedEntities[934] = "Phi".ToCharArray();
+            namedEntities[935] = "Chi".ToCharArray();
+            namedEntities[936] = "Psi".ToCharArray();
+            namedEntities[937] = "Omega".ToCharArray();
+            namedEntities[945] = "alpha".ToCharArray();
+            namedEntities[946] = "beta".ToCharArray();
+            namedEntities[947] = "gamma".ToCharArray();
+            namedEntities[948] = "delta".ToCharArray();
+            namedEntities[949] = "epsilon".ToCharArray();
+            namedEntities[950] = "zeta".ToCharArray();
+            namedEntities[951] = "eta".ToCharArray();
+            namedEntities[952] = "theta".ToCharArray();
+            namedEntities[953] = "iota".ToCharArray();
+            namedEntities[954] = "kappa".ToCharArray();
+            namedEntities[955] = "lambda".ToCharArray();
+            namedEntities[956] = "mu".ToCharArray();
+            namedEntities[957] = "nu".ToCharArray();
+            namedEntities[958] = "xi".ToCharArray();
+            namedEntities[959] = "omicron".ToCharArray();
+            namedEntities[960] = "pi".ToCharArray();
+            namedEntities[961] = "rho".ToCharArray();
+            namedEntities[962] = "sigmaf".ToCharArray();
+            namedEntities[963] = "sigma".ToCharArray();
+            namedEntities[964] = "tau".ToCharArray();
+            namedEntities[965] = "upsilon".ToCharArray();
+            namedEntities[966] = "phi".ToCharArray();
+            namedEntities[967] = "chi".ToCharArray();
+            namedEntities[968] = "psi".ToCharArray();
+            namedEntities[969] = "omega".ToCharArray();
+            namedEntities[977] = "thetasym".ToCharArray();
+            namedEntities[978] = "upsih".ToCharArray();
+            namedEntities[982] = "piv".ToCharArray();
+
+            namedEntities[0x2002] = "ensp".ToCharArray();
+            namedEntities[0x2003] = "emsp".ToCharArray();
+            namedEntities[0x2009] = "thinsp".ToCharArray();
+            namedEntities[0x200C] = "zwnj".ToCharArray();
+            namedEntities[0x200D] = "zwj".ToCharArray();
+            namedEntities[0x200E] = "lrm".ToCharArray();
+            namedEntities[0x200F] = "rlm".ToCharArray();
+            namedEntities[0x2013] = "ndash".ToCharArray();
+            namedEntities[0x2014] = "mdash".ToCharArray();
+            namedEntities[0x2018] = "lsquo".ToCharArray();
+            namedEntities[0x2019] = "rsquo".ToCharArray();
+            namedEntities[0x201A] = "sbquo".ToCharArray();
+            namedEntities[0x201C] = "ldquo".ToCharArray();
+            namedEntities[0x201D] = "rdquo".ToCharArray();
+            namedEntities[0x201E] = "bdquo".ToCharArray();
+            namedEntities[0x2020] = "dagger".ToCharArray();
+            namedEntities[0x2021] = "Dagger".ToCharArray();
+            namedEntities[0x2022] = "bull".ToCharArray();
+            namedEntities[0x2026] = "hellip".ToCharArray();
+            namedEntities[0x2030] = "permil".ToCharArray();
+            namedEntities[0x2032] = "prime".ToCharArray();
+            namedEntities[0x2033] = "Prime".ToCharArray();
+            namedEntities[0x2039] = "lsaquo".ToCharArray();
+            namedEntities[0x203A] = "rsaquo".ToCharArray();
+            namedEntities[0x203E] = "oline".ToCharArray();
+            namedEntities[0x2044] = "frasl".ToCharArray();
+            namedEntities[0x20AC] = "euro".ToCharArray();
+            namedEntities[0x2111] = "image".ToCharArray();
+            namedEntities[0x2118] = "weierp".ToCharArray();
+            namedEntities[0x211C] = "real".ToCharArray();
+            namedEntities[0x2122] = "trade".ToCharArray();
+            namedEntities[0x2135] = "alefsym".ToCharArray();
+            namedEntities[0x2190] = "larr".ToCharArray();
+            namedEntities[0x2191] = "uarr".ToCharArray();
+            namedEntities[0x2192] = "rarr".ToCharArray();
+            namedEntities[0x2193] = "darr".ToCharArray();
+            namedEntities[0x2194] = "harr".ToCharArray();
+            namedEntities[0x21B5] = "crarr".ToCharArray();
+            namedEntities[0x21D0] = "lArr".ToCharArray();
+            namedEntities[0x21D1] = "uArr".ToCharArray();
+            namedEntities[0x21D2] = "rArr".ToCharArray();
+            namedEntities[0x21D3] = "dArr".ToCharArray();
+            namedEntities[0x21D4] = "hArr".ToCharArray();
+            namedEntities[0x2200] = "forall".ToCharArray();
+            namedEntities[0x2202] = "part".ToCharArray();
+            namedEntities[0x2203] = "exist".ToCharArray();
+            namedEntities[0x2205] = "empty".ToCharArray();
+            namedEntities[0x2207] = "nabla".ToCharArray();
+            namedEntities[0x2208] = "isin".ToCharArray();
+            namedEntities[0x2209] = "notin".ToCharArray();
+            namedEntities[0x220B] = "ni".ToCharArray();
+            namedEntities[0x220F] = "prod".ToCharArray();
+            namedEntities[0x2211] = "sum".ToCharArray();
+            namedEntities[0x2212] = "minus".ToCharArray();
+            namedEntities[0x2217] = "lowast".ToCharArray();
+            namedEntities[0x221A] = "radic".ToCharArray();
+            namedEntities[0x221D] = "prop".ToCharArray();
+            namedEntities[0x221E] = "infin".ToCharArray();
+            namedEntities[0x2220] = "ang".ToCharArray();
+            namedEntities[0x2227] = "and".ToCharArray();
+            namedEntities[0x2228] = "or".ToCharArray();
+            namedEntities[0x2229] = "cap".ToCharArray();
+            namedEntities[0x222A] = "cup".ToCharArray();
+            namedEntities[0x222B] = "int".ToCharArray();
+            namedEntities[0x2234] = "there4".ToCharArray();
+            namedEntities[0x223C] = "sim".ToCharArray();
+            namedEntities[0x2245] = "cong".ToCharArray();
+            namedEntities[0x2248] = "asymp".ToCharArray();
+            namedEntities[0x2260] = "ne".ToCharArray();
+            namedEntities[0x2261] = "equiv".ToCharArray();
+            namedEntities[0x2264] = "le".ToCharArray();
+            namedEntities[0x2265] = "ge".ToCharArray();
+            namedEntities[0x2282] = "sub".ToCharArray();
+            namedEntities[0x2283] = "sup".ToCharArray();
+            namedEntities[0x2284] = "nsub".ToCharArray();
+            namedEntities[0x2286] = "sube".ToCharArray();
+            namedEntities[0x2287] = "supe".ToCharArray();
+            namedEntities[0x2295] = "oplus".ToCharArray();
+            namedEntities[0x2297] = "otimes".ToCharArray();
+            namedEntities[0x22A5] = "perp".ToCharArray();
+            namedEntities[0x22C5] = "sdot".ToCharArray();
+            namedEntities[0x2308] = "lceil".ToCharArray();
+            namedEntities[0x2309] = "rceil".ToCharArray();
+            namedEntities[0x230A] = "lfloor".ToCharArray();
+            namedEntities[0x230B] = "rfloor".ToCharArray();
+            namedEntities[0x2329] = "lang".ToCharArray();
+            namedEntities[0x232A] = "rang".ToCharArray();
+            namedEntities[0x25CA] = "loz".ToCharArray();
+            namedEntities[0x2660] = "spades".ToCharArray();
+            namedEntities[0x2663] = "clubs".ToCharArray();
+            namedEntities[0x2665] = "hearts".ToCharArray();
+            namedEntities[0x2666] = "diams".ToCharArray();
+
+            return namedEntities;
+        }
+    }
+}

--- a/source/Core/Internal/AntiXssLibrary/Utf16StringReader.cs
+++ b/source/Core/Internal/AntiXssLibrary/Utf16StringReader.cs
@@ -1,0 +1,140 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Utf16StringReader.cs" company="Microsoft Corporation">
+//   Copyright (c) 2008, 2009, 2010 All Rights Reserved, Microsoft Corporation
+//
+//   This source is subject to the Microsoft Permissive License.
+//   Please see the License.txt file for more information.
+//   All other rights reserved.
+//
+//   THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+//   KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//   IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//   PARTICULAR PURPOSE.
+//
+// </copyright>
+// <summary>
+//   Reads individual scalar values from a UTF-16 input string.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+// ReSharper disable CheckNamespace
+namespace Microsoft.Security.Application
+    // ReSharper restore CheckNamespace
+{
+    /// <summary>
+    /// Reads individual scalar values from a UTF-16 input string.
+    /// </summary>
+    /// <remarks>
+    /// For performance reasons, this is a mutable struct. Use caution when capturing instances of this type.
+    /// </remarks>
+    internal struct Utf16StringReader
+    {
+        /// <summary>
+        /// Starting code point for the UTF-16 leading surrogates.
+        /// </summary>
+        private const char LeadingSurrogateStart = '\uD800';
+
+        /// <summary>
+        /// Starting code point for the UTF-16 trailing surrogates.
+        /// </summary>
+        private const char TrailingSurrogateStart = '\uDC00';
+
+        /// <summary>
+        /// The Unicode replacement character U+FFFD.
+        /// </summary>
+        /// <remarks>
+        /// For more info, see http://www.unicode.org/charts/PDF/UFFF0.pdf.
+        /// </remarks>
+        private const int UnicodeReplacementCharacterCodePoint = '\uFFFD';
+
+        /// <summary>
+        /// The input string we're iterating on.
+        /// </summary>
+        private readonly string input;
+
+        /// <summary>
+        /// The current offset into 'input'.
+        /// </summary>
+        private int currentOffset;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Utf16StringReader"/> struct with the given UTF-16 input string.
+        /// </summary>
+        /// <param name="input">The input string to decompose into scalar values.</param>
+        public Utf16StringReader(string input)
+        {
+            this.input = input;
+            this.currentOffset = 0;
+        }
+
+        /// <summary>
+        /// Reads the next scalar value from the input string.
+        /// </summary>
+        /// <returns>The next scalar value. If the input string contains invalid UTF-16, the
+        /// return value is the Unicode replacement character U+FFFD. If the end of the string
+        /// is reached, returns -1.</returns>
+        public int ReadNextScalarValue()
+        {
+            if (this.currentOffset >= this.input.Length)
+            {
+                return -1; // EOF
+            }
+
+            char thisCodeUnit = this.input[this.currentOffset++];
+            int thisCodePoint = thisCodeUnit;
+
+            if (char.IsHighSurrogate(thisCodeUnit))
+            {
+                if (this.currentOffset < this.input.Length)
+                {
+                    char nextCodeUnit = this.input[this.currentOffset];
+                    if (char.IsLowSurrogate(nextCodeUnit))
+                    {
+                        // We encountered a high (leading) surrogate followed by a low
+                        // (trailing) surrogate. Bump 'currentOffset' up by one more
+                        // since we're consuming both code units.
+                        this.currentOffset++;
+                        thisCodePoint = ConvertToUtf32(thisCodeUnit, nextCodeUnit);
+                    }
+                }
+            }
+
+            if (IsValidUnicodeScalarValue(thisCodePoint))
+            {
+                return thisCodePoint;
+            }
+
+            // ERROR: This code point was either an unmatched high (leading)
+            // surrogate or an unmatched low (trailing) surrogate, neither of
+            // which maps to a valid Unicode scalar value. Per the Unicode
+            // specification (Ch. 3, C10), we replace with U+FFFD.
+            return UnicodeReplacementCharacterCodePoint;
+        }
+
+        /// <summary>
+        /// Similar to Char.ConvertToUtf32, but slightly faster in tight loops since parameter checks are not done.
+        /// </summary>
+        /// <param name="leadingSurrogate">The UTF-16 leading surrogate character.</param>
+        /// <param name="trailingSurrogate">The UTF-16 trailing surrogate character.</param>
+        /// <returns>The scalar value resulting from combining these two surrogate characters.</returns>
+        /// <remarks>The caller must ensure that the inputs are valid surrogate characters. If not,
+        /// the output of this routine is undefined.</remarks>
+        private static int ConvertToUtf32(char leadingSurrogate, char trailingSurrogate)
+        {
+            return (((leadingSurrogate - LeadingSurrogateStart) * 0x400) + (trailingSurrogate - TrailingSurrogateStart)) + 0x10000;
+        }
+
+        /// <summary>
+        /// Determines whether a given code point is a valid Unicode scalar value.
+        /// </summary>
+        /// <param name="codePoint">The code point whose validity is to be checked.</param>
+        /// <returns>True if the input is a valid Unicode scalar value, false otherwise.</returns>
+        private static bool IsValidUnicodeScalarValue(int codePoint)
+        {
+            // Valid scalar values are U+0000 .. U+D7FF and U+E000 .. U+10FFFF.
+            // See: http://www.unicode.org/versions/Unicode6.0.0/ch03.pdf, D76
+            return (0 <= codePoint && codePoint <= 0xD7FF)
+                || (0xE000 <= codePoint && codePoint <= 0x10FFFF);
+        }
+    }
+}

--- a/source/Core/packages.config
+++ b/source/Core/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AntiXSS" version="4.3.0" targetFramework="net45" />
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
   <package id="Autofac.WebApi2" version="3.4.0" targetFramework="net45" />
   <package id="ILMerge" version="2.14.1208" targetFramework="net45" />


### PR DESCRIPTION
All tests pass, but I don't think this is being tested.

`System.IdentityModel.Tokens.Jwt` has a dependency on `System.Web.Extensions` (which also has a dependency on `System.Web` so I can't get rid of that. However ilmerge is not bringing `System.Web` through so I can live with that.