### PR TITLE
SigninMessageThreshold as an option

### DIFF
--- a/source/Core/Configuration/AuthenticationOptions.cs
+++ b/source/Core/Configuration/AuthenticationOptions.cs
@@ -37,6 +37,7 @@ namespace Thinktecture.IdentityServer.Core.Configuration
             PostSignOutAutoRedirectDelay = 0;
             RequireAuthenticatedUserForSignOutMessage = false;
             CookieOptions = new CookieOptions();
+            SignInMessageThreshold = Constants.SignInMessageThreshold;
         }
 
         /// <summary>
@@ -123,5 +124,14 @@ namespace Thinktecture.IdentityServer.Core.Configuration
         /// A callback function for configuring identity providers.
         /// </value>
         public Action<IAppBuilder, string> IdentityProviders { get; set; }
+
+        /// <summary>
+        /// Gets or sets the limit after which old signin messages are purged.
+        /// Defaults to the value defined in <see cref="Constants.SignInMessageThreshold"/> value.
+        /// </summary>
+        /// <value>
+        /// The limit after which old signin messages are purged
+        /// </value>
+        public int SignInMessageThreshold { get; set; }
     }
 }

--- a/source/Core/Configuration/Hosting/MessageCookie.cs
+++ b/source/Core/Configuration/Hosting/MessageCookie.cs
@@ -220,7 +220,7 @@ namespace Thinktecture.IdentityServer.Core.Configuration.Hosting
             var names = GetCookieNames();
             var toKeep = options.AuthenticationOptions.SignInMessageThreshold;
 
-            if (names.Count() > toKeep)
+            if (names.Count() >= toKeep)
             {
                 var rankedCookieNames =
                     from name in names

--- a/source/Core/Configuration/Hosting/MessageCookie.cs
+++ b/source/Core/Configuration/Hosting/MessageCookie.cs
@@ -218,7 +218,9 @@ namespace Thinktecture.IdentityServer.Core.Configuration.Hosting
         private void ClearOverflow()
         {
             var names = GetCookieNames();
-            if (names.Count() > Constants.SignInMessageThreshold)
+            var toKeep = options.AuthenticationOptions.SignInMessageThreshold;
+
+            if (names.Count() > toKeep)
             {
                 var rankedCookieNames =
                     from name in names
@@ -226,7 +228,7 @@ namespace Thinktecture.IdentityServer.Core.Configuration.Hosting
                     orderby rank descending
                     select name;
 
-                var purge = rankedCookieNames.Skip(Constants.SignInMessageThreshold);
+                var purge = rankedCookieNames.Skip(Math.Max(0, toKeep - 1));
                 foreach (var name in purge)
                 {
                     ClearByCookieName(name);

--- a/source/Tests/UnitTests/Configuration/AuthenticationOptionsTests.cs
+++ b/source/Tests/UnitTests/Configuration/AuthenticationOptionsTests.cs
@@ -1,0 +1,19 @@
+﻿using FluentAssertions;
+using Thinktecture.IdentityServer.Core;
+using Thinktecture.IdentityServer.Core.Configuration;
+using Xunit;
+
+namespace Thinktecture.IdentityServer.Tests.Configuration
+{
+    public class AuthenticationOptionsTests
+    {
+        [Fact]
+        public void SigninMessageThreshold_Default_SameAsDefinedConstant()
+        {
+            new AuthenticationOptions()
+                .SignInMessageThreshold
+                .Should()
+                .Be(Constants.SignInMessageThreshold);
+        }
+    }
+}

--- a/source/Tests/UnitTests/Core.Tests.csproj
+++ b/source/Tests/UnitTests/Core.Tests.csproj
@@ -141,6 +141,7 @@
       <Link>Properties\VersionAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="ClassVisibilityTests.cs" />
+    <Compile Include="Configuration\AuthenticationOptionsTests.cs" />
     <Compile Include="Configuration\Hosting\AntiForgeryTokenValidatorTest.cs" />
     <Compile Include="Conformance\Basic\RedirectUriTests.cs" />
     <Compile Include="Conformance\Basic\ClientAuthenticationTests.cs" />

--- a/source/Tests/UnitTests/Endpoints/AuthenticationControllerTests.cs
+++ b/source/Tests/UnitTests/Endpoints/AuthenticationControllerTests.cs
@@ -977,6 +977,55 @@ namespace Thinktecture.IdentityServer.Tests.Endpoints
         }
 
         [Fact]
+        public void GetLogin_SigninMessageThresholdSetToX_GetLoginMoreThanXTimesOnlyLatestXMessagesAreKept()
+        {
+            options.AuthenticationOptions.SignInMessageThreshold = 3;
+            var moreThanSignInThreshold = options.AuthenticationOptions.SignInMessageThreshold + 1;
+
+            for (var i = 0; i < moreThanSignInThreshold; i++)
+            {
+                GetLoginPage();
+            }
+
+            var theNextRequest = GetLoginPage();
+            theNextRequest.RequestMessage.Headers
+                .GetValues("Cookie")
+                .Count(c => c.StartsWith("SignInMessage."))
+                .Should()
+                .Be(options.AuthenticationOptions.SignInMessageThreshold);
+        }
+
+        [Fact]
+        public void GetLogin_SigninMessageThresholdSetToZero_OneSignInMessageKept()
+        {
+            options.AuthenticationOptions.SignInMessageThreshold = 0;
+
+            GetLoginPage();
+
+            var theNextRequest = GetLoginPage();
+            theNextRequest.RequestMessage.Headers
+                .GetValues("Cookie")
+                .Count(c => c.StartsWith("SignInMessage."))
+                .Should()
+                .Be(1);
+        }
+
+        [Fact]
+        public void GetLogin_SigninMessageThresholdSetToNegative_OneSignInMessageKept()
+        {
+            options.AuthenticationOptions.SignInMessageThreshold = -42;
+
+            GetLoginPage();
+
+            var theNextRequest = GetLoginPage();
+            theNextRequest.RequestMessage.Headers
+                .GetValues("Cookie")
+                .Count(c => c.StartsWith("SignInMessage."))
+                .Should()
+                .Be(1);
+        }
+
+        [Fact]
         public void PostLogin_SignInIdTooLong_ReturnsError()
         {
             var resp = GetLoginPage();

--- a/source/Tests/UnitTests/Endpoints/AuthenticationControllerTests.cs
+++ b/source/Tests/UnitTests/Endpoints/AuthenticationControllerTests.cs
@@ -977,6 +977,25 @@ namespace Thinktecture.IdentityServer.Tests.Endpoints
         }
 
         [Fact]
+        public void GetLogin_SigninMessageThresholdSetToX_GetLoginXTimesOnlyLatestXMessagesAreKept()
+        {
+            const int signInMessageThreshold = 3;
+            options.AuthenticationOptions.SignInMessageThreshold = signInMessageThreshold;
+
+            for (var i = 0; i < signInMessageThreshold; i++)
+            {
+                GetLoginPage();
+            }
+
+            var theNextRequest = GetLoginPage();
+            theNextRequest.RequestMessage.Headers
+                .GetValues("Cookie")
+                .Count(c => c.StartsWith("SignInMessage."))
+                .Should()
+                .Be(options.AuthenticationOptions.SignInMessageThreshold);
+        }
+
+        [Fact]
         public void GetLogin_SigninMessageThresholdSetToX_GetLoginMoreThanXTimesOnlyLatestXMessagesAreKept()
         {
             options.AuthenticationOptions.SignInMessageThreshold = 3;

--- a/source/Tests/UnitTests/Endpoints/Setup/IdSvrHostTestBase.cs
+++ b/source/Tests/UnitTests/Endpoints/Setup/IdSvrHostTestBase.cs
@@ -59,7 +59,7 @@ namespace Thinktecture.IdentityServer.Tests.Endpoints
         protected GoogleOAuth2AuthenticationOptions google;
         protected GoogleOAuth2AuthenticationOptions google2;
         protected GoogleOAuth2AuthenticationOptions hiddenGoogle;
-        
+
         public IdSvrHostTestBase()
         {
             Init();
@@ -118,7 +118,7 @@ namespace Thinktecture.IdentityServer.Tests.Endpoints
                 ClientSecret = "bar"
             };
             app.UseGoogleAuthentication(google);
-            
+
             google2 = new GoogleOAuth2AuthenticationOptions
             {
                 Caption = "Google2",
@@ -128,7 +128,7 @@ namespace Thinktecture.IdentityServer.Tests.Endpoints
                 ClientSecret = "g2"
             };
             app.UseGoogleAuthentication(google2);
-            
+
             hiddenGoogle = new GoogleOAuth2AuthenticationOptions
             {
                 AuthenticationType = "HiddenGoogle",
@@ -200,7 +200,7 @@ namespace Thinktecture.IdentityServer.Tests.Endpoints
         protected string ToFormBody(NameValueCollection coll)
         {
             var sb = new StringBuilder();
-            foreach(var item in coll.AllKeys)
+            foreach (var item in coll.AllKeys)
             {
                 if (sb.Length > 0)
                 {
@@ -233,7 +233,7 @@ namespace Thinktecture.IdentityServer.Tests.Endpoints
         {
             return client.PostAsJsonAsync(Url(path), value).Result;
         }
-        
+
         protected HttpResponseMessage Put<T>(string path, T value)
         {
             return client.PutAsJsonAsync(Url(path), value).Result;
@@ -247,7 +247,13 @@ namespace Thinktecture.IdentityServer.Tests.Endpoints
         protected string WriteMessageToCookie<T>(T msg)
             where T : Message
         {
-            var request_headers = new Dictionary<string, string[]>();
+            var cookieStates = client.DefaultRequestHeaders.GetCookies().SelectMany(c => c.Cookies);
+            var requestCookies = cookieStates.Select(c => c.ToString()).ToArray();
+            var request_headers = new Dictionary<string, string[]>
+            {
+                {"Cookie", requestCookies}
+            };
+
             var response_headers = new Dictionary<string, string[]>();
             var env = new Dictionary<string, object>()
             {


### PR DESCRIPTION
#### Summary:
* Solves #1010.
* `SignInMessageThreshold` property on `AuthenticationOptions`
* `MessageCookie.ClearOverflow` now uses the option value rather than the constant

#### Additional comments:
* CLA is signed
* The default threshold value is 5. Ealier, this resulted in 6 SignInMessage cookies. Now, if 5 is defined, 5 cookies are kept. Simply because it was difficult to explain in unit test the off by 1 behavior.
* There is some (intentionally?) duplicated code in the test project. For unit testing, `IdSvrHostTestBase.WriteMessageToCookie<T>` and `Thinktecture.IdentityServer.Tests.Endpoints.Setup.Extensions.cs` were modified. There are similar functionalities in the `Conformance` ns that are not touched. Didn't want to make the PR too messy.